### PR TITLE
style: fix prettier formatting issues

### DIFF
--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -6,14 +6,14 @@ import { CreateOptions } from '../../types/index.js'
 
 vi.mock('execa')
 vi.mock('../../utils/tmux.js', () => ({
-  setupTmuxStatusLine: vi.fn().mockResolvedValue(undefined)
+  setupTmuxStatusLine: vi.fn().mockResolvedValue(undefined),
 }))
 
 describe('createTmuxSession - pane split options', () => {
   const mockConfig: Config = {
     worktrees: { root: '.git/orchestrations' },
     development: {},
-    integrations: {}
+    integrations: {},
   }
 
   beforeEach(() => {
@@ -22,63 +22,49 @@ describe('createTmuxSession - pane split options', () => {
 
   it('should split pane horizontally with --tmux-h option', async () => {
     const options: CreateOptions = { tmuxH: true }
-    
+
     await createTmuxSession('feature-test', '/path/to/worktree', mockConfig, options)
-    
-    expect(execa).toHaveBeenCalledWith('tmux', [
-      'split-window',
-      '-h',
-      '-c',
-      '/path/to/worktree'
-    ])
-    
-    expect(execa).toHaveBeenCalledWith('tmux', [
-      'select-pane',
-      '-T',
-      'feature-test'
-    ])
+
+    expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-h', '-c', '/path/to/worktree'])
+
+    expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
   })
 
   it('should split pane vertically with --tmux-v option', async () => {
     const options: CreateOptions = { tmuxV: true }
-    
+
     await createTmuxSession('feature-test', '/path/to/worktree', mockConfig, options)
-    
-    expect(execa).toHaveBeenCalledWith('tmux', [
-      'split-window',
-      '-v',
-      '-c',
-      '/path/to/worktree'
-    ])
+
+    expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-v', '-c', '/path/to/worktree'])
   })
 
   it('should send claude command when claude option is enabled', async () => {
     const options: CreateOptions = { tmuxH: true, claude: true }
-    
+
     await createTmuxSession('issue-123', '/path/to/worktree', mockConfig, options)
-    
+
     expect(execa).toHaveBeenCalledWith('tmux', [
       'send-keys',
       '-t',
       ':.',
       'claude "fix issue 123"',
-      'Enter'
+      'Enter',
     ])
   })
 
   it('should create new session with regular --tmux option', async () => {
     const options: CreateOptions = { tmux: true }
     vi.mocked(execa).mockRejectedValueOnce(new Error('no session')) // has-session fails
-    
+
     await createTmuxSession('feature-test', '/path/to/worktree', mockConfig, options)
-    
+
     expect(execa).toHaveBeenCalledWith('tmux', [
       'new-session',
       '-d',
       '-s',
       'feature-test',
       '-c',
-      '/path/to/worktree'
+      '/path/to/worktree',
     ])
   })
 })

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -159,40 +159,42 @@ export async function createTmuxSession(
     if (options?.tmuxH || options?.tmuxV) {
       // 現在のtmuxセッション内でペインを分割
       const splitArgs = ['split-window']
-      
+
       if (options.tmuxH) {
         splitArgs.push('-h') // 水平分割（左右）
       } else if (options.tmuxV) {
         splitArgs.push('-v') // 垂直分割（上下）
       }
-      
+
       splitArgs.push('-c', worktreePath)
       await execa('tmux', splitArgs)
-      
+
       // 新しいペインにタイトルを設定
       await execa('tmux', ['select-pane', '-T', branchName])
-      
+
       // tmuxステータスラインを設定
       await setupTmuxStatusLine()
-      
+
       // 新しいペインでClaudeコマンドを実行（オプションが有効な場合）
       if (options.claude || config.claude?.autoStart) {
         // Issue番号からの作成の場合、説明を含める
         let claudeCommand = 'claude'
-        
+
         if (branchName.includes('issue-')) {
           const issueNumber = branchName.match(/issue-(\d+)/)?.[1]
           if (issueNumber) {
             claudeCommand = `claude "fix issue ${issueNumber}"`
           }
         }
-        
+
         // 新しいペインにコマンドを送信
         await execa('tmux', ['send-keys', '-t', ':.', claudeCommand, 'Enter'])
       }
-      
+
       // 新しいペインでシェルのプロンプトを表示
-      console.log(chalk.green(`✅ tmuxペインを${options.tmuxH ? '水平' : '垂直'}分割しました: ${branchName}`))
+      console.log(
+        chalk.green(`✅ tmuxペインを${options.tmuxH ? '水平' : '垂直'}分割しました: ${branchName}`)
+      )
       return
     }
 

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -338,7 +338,10 @@ async function executeWorktreesDeletion(
     const deleteSpinner = ora(`演奏者 '${chalk.cyan(branch)}' を解散中...`).start()
 
     try {
-      await gitManager.deleteWorktree(worktree.branch?.replace('refs/heads/', '') || '', options.force)
+      await gitManager.deleteWorktree(
+        worktree.branch?.replace('refs/heads/', '') || '',
+        options.force
+      )
       deleteSpinner.succeed(`演奏者 '${chalk.cyan(branch)}' を解散しました`)
 
       if (options.removeRemote && worktree.branch) {

--- a/src/utils/tmux.ts
+++ b/src/utils/tmux.ts
@@ -10,9 +10,9 @@ export async function setupTmuxStatusLine(): Promise<void> {
       'set-option',
       '-g',
       'status-right',
-      '#[fg=yellow]#{?client_prefix,#[reverse]<Prefix>#[noreverse] ,}#[fg=cyan]#(cd #{pane_current_path} && git branch --show-current 2>/dev/null || echo "no branch") #[fg=white]| %H:%M'
+      '#[fg=yellow]#{?client_prefix,#[reverse]<Prefix>#[noreverse] ,}#[fg=cyan]#(cd #{pane_current_path} && git branch --show-current 2>/dev/null || echo "no branch") #[fg=white]| %H:%M',
     ])
-    
+
     // ペインボーダーにタイトルを表示
     await execa('tmux', ['set-option', '-g', 'pane-border-status', 'top'])
     await execa('tmux', ['set-option', '-g', 'pane-border-format', ' #{pane_title} '])


### PR DESCRIPTION
## Summary
- Fix prettier formatting issues in 4 files that were causing CI failures
- Resolves formatting errors from commit 631c6ba

## Files Changed
- `src/__tests__/commands/create-tmux.test.ts` - Test formatting fixes
- `src/commands/create.ts` - Tmux session formatting fixes  
- `src/commands/delete.ts` - Delete command formatting fixes
- `src/utils/tmux.ts` - Tmux utility formatting fixes

## Test plan
- [x] `npm run prettier:check` passes
- [x] `npm run lint` passes (warnings only)
- [x] `npm run typecheck` passes
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.ai/code)