### PR TITLE
docs: translate Japanese documentation to English

### DIFF
--- a/docs/commands/batch.md
+++ b/docs/commands/batch.md
@@ -1,54 +1,54 @@
 # mst batch
 
-複数の演奏者（Git Worktree）を一括で作成・管理するコマンドです。GitHub Issues、ファイル入力、対話形式など、様々な方法で効率的に複数のWorktreeを作成できます。
+Command to batch create and manage multiple orchestra members (Git Worktrees). You can efficiently create multiple Worktrees through various methods including GitHub Issues, file input, and interactive mode.
 
-## 概要
+## Overview
 
 ```bash
 mst batch [options]
-mst b [options]  # エイリアス
+mst b [options]  # alias
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# GitHub Issuesから複数選択して一括作成
+# Batch create by selecting multiple GitHub Issues
 mst batch
 
-# ファイルから一括作成
+# Batch create from file
 mst batch --from-file worktrees.txt
 
-# インタラクティブに複数入力
+# Interactive multiple input
 mst batch --interactive
 
-# オプションを付けて一括作成
-mst batch -o -s -b develop  # 作成後に開く、セットアップ実行、ベースはdevelop
+# Batch create with options
+mst batch -o -s -b develop  # Open after creation, run setup, base is develop
 ```
 
-## オプション
+## Options
 
-| オプション | 短縮形 | 説明 | デフォルト |
-|-----------|--------|------|-----------|
-| `--from-file <file>` | `-f` | バッチファイルから読み込み | なし |
-| `--interactive` | `-i` | インタラクティブ入力モード | `false` |
-| `--open` | `-o` | 作成後にエディタで開く | `false` |
-| `--setup` | `-s` | 環境セットアップを実行 | `false` |
-| `--base <branch>` | `-b` | ベースブランチを指定 | `main` |
-| `--template <name>` | `-t` | 使用するテンプレート | なし |
-| `--parallel <n>` | `-p` | 並列実行数 | `4` |
-| `--dry-run` | `-n` | 実際には作成せず、計画を表示 | `false` |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--from-file <file>` | `-f` | Read from batch file | none |
+| `--interactive` | `-i` | Interactive input mode | `false` |
+| `--open` | `-o` | Open in editor after creation | `false` |
+| `--setup` | `-s` | Run environment setup | `false` |
+| `--base <branch>` | `-b` | Specify base branch | `main` |
+| `--template <name>` | `-t` | Template to use | none |
+| `--parallel <n>` | `-p` | Number of parallel executions | `4` |
+| `--dry-run` | `-n` | Show plan without actually creating | `false` |
 
-## GitHub Issuesモード（デフォルト）
+## GitHub Issues Mode (Default)
 
-引数なしで実行すると、GitHub Issuesから複数選択できます：
+When run without arguments, you can select multiple issues from GitHub:
 
 ```bash
 mst batch
 ```
 
-選択画面：
+Selection screen:
 ```
 ? Select issues to create worktrees from: (Press <space> to select, <a> to toggle all)
  ◉ #125 feat: Add authentication system (enhancement)
@@ -58,7 +58,7 @@ mst batch
  ◉ #121 feat: Dark mode support (ui, enhancement)
 ```
 
-実行結果：
+Execution result:
 ```
 Creating 3 worktrees...
 
@@ -69,111 +69,111 @@ Creating 3 worktrees...
 Summary: 3 successful, 0 failed
 ```
 
-## ファイル入力モード
+## File Input Mode
 
-### バッチファイルフォーマット
+### Batch File Format
 
 ```bash
 # worktrees.txt
-# フォーマット: branch-name | description | issue/pr番号（オプション）
+# Format: branch-name | description | issue/pr number (optional)
 
-feature-auth | 認証機能の実装 | #125
-bugfix-login | ログインバグの修正 | pr-45
-refactor-api | APIのリファクタリング
-docs-update | ドキュメントの更新 | issue-123
+feature-auth | Implement authentication | #125
+bugfix-login | Fix login bug | pr-45
+refactor-api | API refactoring
+docs-update | Update documentation | issue-123
 
-# コメント行は無視されます
-# 空行も無視されます
+# Comment lines are ignored
+# Empty lines are also ignored
 ```
 
-### 実行
+### Execution
 
 ```bash
 mst batch --from-file worktrees.txt
 ```
 
-### CSVフォーマットもサポート
+### CSV Format Support
 
 ```csv
 branch,description,issue
-feature-auth,"認証機能の実装",125
-bugfix-login,"ログインバグの修正",pr-45
-refactor-api,"APIのリファクタリング",
-docs-update,"ドキュメントの更新",issue-123
+feature-auth,"Implement authentication",125
+bugfix-login,"Fix login bug",pr-45
+refactor-api,"API refactoring",
+docs-update,"Update documentation",issue-123
 ```
 
-## インタラクティブモード
+## Interactive Mode
 
 ```bash
 mst batch --interactive
 ```
 
-プロンプト表示：
+Prompt display:
 ```
 Enter worktree details (branch-name | description | issue/pr)
 Press Enter twice to finish
 
-> feature-auth | 認証機能の実装 | #125
-> bugfix-login | ログインバグの修正
-> refactor-api | APIのリファクタリング
+> feature-auth | Implement authentication | #125
+> bugfix-login | Fix login bug
+> refactor-api | API refactoring
 > 
 
 Creating 3 worktrees...
 ```
 
-## 並列実行
+## Parallel Execution
 
-デフォルトでは4つまで並列で作成されます：
+By default, up to 4 worktrees are created in parallel:
 
 ```bash
-# 並列数を変更
+# Change parallel count
 mst batch --parallel 8
 
-# 逐次実行（デバッグ用）
+# Sequential execution (for debugging)
 mst batch --parallel 1
 ```
 
-## 実行計画の確認
+## Execution Plan Confirmation
 
 ```bash
-# ドライランで計画を確認
+# Dry run to check plan
 mst batch --from-file worktrees.txt --dry-run
 ```
 
-出力例：
+Example output:
 ```
 Batch execution plan:
 1. feature-auth (base: main, template: none)
-   - Description: 認証機能の実装
+   - Description: Implement authentication
    - GitHub Issue: #125
 2. bugfix-login (base: main, template: none)
-   - Description: ログインバグの修正
+   - Description: Fix login bug
    - GitHub PR: #45
 3. refactor-api (base: main, template: none)
-   - Description: APIのリファクタリング
+   - Description: API refactoring
 
 Total: 3 worktrees to create
 Options: --open --setup
 ```
 
-## テンプレートの使用
+## Template Usage
 
 ```bash
-# 全てにfeatureテンプレートを適用
+# Apply feature template to all
 mst batch --template feature
 
-# ファイルで個別指定
+# Individual specification in file
 # worktrees-with-template.txt
-feature-auth | 認証機能 | #125 | template:feature
-bugfix-login | バグ修正 | | template:bugfix
-experiment-ml | 機械学習実験 | | template:experiment
+feature-auth | Authentication | #125 | template:feature
+bugfix-login | Bug fix | | template:bugfix
+experiment-ml | ML experiment | | template:experiment
 ```
 
-## エラーハンドリング
+## Error Handling
 
-### 部分的な失敗
+### Partial Failures
 
-一部の作成が失敗しても、他は継続されます：
+If some creations fail, others continue:
 
 ```
 Creating 5 worktrees...
@@ -191,75 +191,75 @@ Failed worktrees:
 - feature-ui: Invalid branch name
 ```
 
-### リトライ機能
+### Retry Feature
 
 ```bash
-# 失敗したものだけ再実行
+# Re-run only failed ones
 mst batch --retry-failed
 
-# または失敗リストをファイルに保存
+# Or save failed list to file
 mst batch --save-failed failed.txt
 ```
 
-## 高度な使用例
+## Advanced Usage Examples
 
-### プロジェクト初期設定
+### Project Initial Setup
 
 ```bash
 # setup-project.txt
-feature-auth | 認証システム | #10
-feature-api | REST API実装 | #11
-feature-ui | フロントエンドUI | #12
-docs-api | APIドキュメント | #13
-test-integration | 統合テスト | #14
+feature-auth | Authentication system | #10
+feature-api | REST API implementation | #11
+feature-ui | Frontend UI | #12
+docs-api | API documentation | #13
+test-integration | Integration tests | #14
 
-# 一括作成してセットアップ
+# Batch create and setup
 mst batch --from-file setup-project.txt --setup --open
 ```
 
-### チーム開発での利用
+### Team Development Usage
 
 ```bash
-# チームメンバーごとにIssueを割り当て
+# Assign issues per team member
 ASSIGNED_ISSUES=$(gh issue list --assignee @me --json number -q '.[].number')
 
-# 自分の担当分だけ演奏者を作成
+# Create orchestra members for assigned issues only
 echo "$ASSIGNED_ISSUES" | while read issue; do
   echo "issue-$issue | Issue #$issue | #$issue"
 done | mst batch --from-file -
 ```
 
-### CI/CDでの自動化
+### CI/CD Automation
 
 ```bash
 #!/bin/bash
 # auto-create-worktrees.sh
 
-# ラベルが"ready-for-dev"のIssueを取得
+# Get issues with "ready-for-dev" label
 gh issue list --label ready-for-dev --json number,title | \
   jq -r '.[] | "issue-\(.number) | \(.title) | #\(.number)"' | \
   mst batch --from-file - --setup
 
-# 作成完了後、ラベルを更新
+# Update labels after creation
 gh issue list --label ready-for-dev --json number -q '.[].number' | \
   while read issue; do
     gh issue edit "$issue" --remove-label ready-for-dev --add-label in-progress
   done
 ```
 
-## バッチ操作のベストプラクティス
+## Batch Operations Best Practices
 
-### 1. 命名規則の統一
+### 1. Unified Naming Convention
 
 ```bash
 # naming-convention.txt
-feature/auth-system | 認証システム | #125
-feature/user-profile | ユーザープロフィール | #126
-bugfix/auth-timeout | 認証タイムアウト修正 | #127
-docs/auth-api | 認証APIドキュメント | #128
+feature/auth-system | Authentication system | #125
+feature/user-profile | User profile | #126
+bugfix/auth-timeout | Fix authentication timeout | #127
+docs/auth-api | Authentication API docs | #128
 ```
 
-### 2. 段階的な作成
+### 2. Staged Creation
 
 ```bash
 # Phase 1: Core features
@@ -272,19 +272,19 @@ mst batch --from-file phase2-features.txt
 mst batch --from-file phase3-docs.txt --template docs
 ```
 
-### 3. 進捗管理
+### 3. Progress Management
 
 ```bash
-# バッチ実行結果をログに保存
+# Save batch execution results to log
 mst batch --from-file worktrees.txt | tee batch-$(date +%Y%m%d-%H%M%S).log
 
-# 作成済みの演奏者を確認
+# Check created orchestra members
 mst list --json | jq '.summary'
 ```
 
-## 設定ファイルとの連携
+## Configuration File Integration
 
-`.mst.json` でバッチ処理のデフォルトを設定：
+Set batch processing defaults in `.mst.json`:
 
 ```json
 {
@@ -303,7 +303,7 @@ mst list --json | jq '.summary'
 
 ## Tips & Tricks
 
-### スクリプト化
+### Scripting
 
 ```bash
 #!/bin/bash
@@ -317,14 +317,14 @@ echo "$ISSUES" | jq -r '.[] | "sprint23-\(.number) | \(.title) | #\(.number)"' >
 mst batch --from-file sprint23.txt --base develop --setup --parallel 8
 ```
 
-### 進捗バー付き実行
+### Progress Bar Execution
 
 ```bash
-# バッチファイルの行数を取得
+# Get line count from batch file
 TOTAL=$(wc -l < worktrees.txt)
 CURRENT=0
 
-# 進捗を表示しながら実行
+# Execute with progress display
 while IFS='|' read -r branch desc issue; do
   ((CURRENT++))
   echo "[$CURRENT/$TOTAL] Creating $branch..."
@@ -332,9 +332,9 @@ while IFS='|' read -r branch desc issue; do
 done < worktrees.txt
 ```
 
-## 関連コマンド
+## Related Commands
 
-- [`mst create`](./create.md) - 単一の演奏者を作成
-- [`mst github`](./github.md) - GitHub連携での作成
-- [`mst list`](./list.md) - 作成した演奏者の確認
-- [`mst health`](./health.md) - 大量作成後の健全性チェック
+- [`mst create`](./create.md) - Create single orchestra member
+- [`mst github`](./github.md) - Create from GitHub integration
+- [`mst list`](./list.md) - Check created orchestra members
+- [`mst health`](./health.md) - Health check after bulk creation

--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -1,129 +1,129 @@
 # mst create
 
-演奏者（Git Worktree）を作成するコマンドです。新しいブランチとWorktreeを同時に作成し、独立した開発環境を構築します。
+Command to create orchestra members (Git Worktrees). Creates a new branch and worktree simultaneously, building an independent development environment.
 
-## 概要
+## Overview
 
 ```bash
 mst create <branch-name> [options]
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# 新しい演奏者を作成
+# Create a new orchestra member
 mst create feature/new-feature
 
-# Issue番号から演奏者を作成
-mst create 123           # issue-123として作成
-mst create #123          # issue-123として作成
-mst create issue-123     # issue-123として作成
+# Create orchestra member from issue number
+mst create 123           # Created as issue-123
+mst create #123          # Created as issue-123
+mst create issue-123     # Created as issue-123
 ```
 
-### 高度な使用方法
+### Advanced Usage
 
 ```bash
-# tmuxセッション付きで作成（Claude Code自動起動）
+# Create with tmux session (auto-start Claude Code)
 mst create feature/new-feature --tmux --claude
 
-# Draft PRを自動作成
+# Auto-create Draft PR
 mst create feature/new-feature --draft-pr
 
-# ベースブランチを指定して作成
+# Create with specified base branch
 mst create feature/new-feature --base develop
 
-# テンプレートを使用して作成
+# Create using template
 mst create feature/new-feature --template feature
 
-# 全てのオプションを組み合わせて使用
+# Combine all options
 mst create feature/new-feature --base main --open --setup --tmux --claude --draft-pr
 ```
 
-## オプション
+## Options
 
-| オプション | 短縮形 | 説明 | デフォルト |
-|-----------|--------|------|-----------|
-| `--base <branch>` | `-b` | ベースブランチを指定 | `main` |
-| `--open` | `-o` | 作成後にエディタで開く | `false` |
-| `--setup` | `-s` | 環境セットアップを実行（npm install等） | `false` |
-| `--tmux` | `-t` | tmuxセッション/ウィンドウを作成 | `false` |
-| `--claude` | `-c` | Claude Codeを自動起動 | `false` |
-| `--draft-pr` | `-d` | GitHub Draft PRを自動作成 | `false` |
-| `--template <name>` | | テンプレートを使用 | なし |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--base <branch>` | `-b` | Specify base branch | `main` |
+| `--open` | `-o` | Open in editor after creation | `false` |
+| `--setup` | `-s` | Run environment setup (npm install, etc.) | `false` |
+| `--tmux` | `-t` | Create tmux session/window | `false` |
+| `--claude` | `-c` | Auto-start Claude Code | `false` |
+| `--draft-pr` | `-d` | Auto-create GitHub Draft PR | `false` |
+| `--template <name>` | | Use template | none |
 
-## Issue番号からの作成
+## Creating from Issue Number
 
-Issue番号を指定すると、GitHub APIを使用して自動的にIssue情報を取得し、メタデータとして保存します：
+When you specify an issue number, it automatically fetches issue information using the GitHub API and saves it as metadata:
 
 ```bash
-# 以下のいずれの形式でも可能
+# Any of these formats work
 mst create 123
 mst create #123
 mst create issue-123
 ```
 
-取得される情報：
-- Issueのタイトル
-- Issue本文
-- ラベル
-- 担当者
-- マイルストーン
-- 作成者情報
+Retrieved information:
+- Issue title
+- Issue body
+- Labels
+- Assignees
+- Milestone
+- Author information
 
-## テンプレート機能
+## Template Feature
 
-事前定義されたテンプレートを使用して、特定の設定を持つ演奏者を作成できます：
+You can create orchestra members with predefined templates using specific settings:
 
 ```bash
-# 機能開発用テンプレート
+# Feature development template
 mst create feature/auth --template feature
 
-# バグ修正用テンプレート
+# Bug fix template
 mst create bugfix/login --template bugfix
 
-# 実験用テンプレート
+# Experimental template
 mst create experiment/new-arch --template experiment
 ```
 
-利用可能なテンプレート：
-- `feature`: 新機能開発用（Claude Code自動起動）
-- `bugfix`: バグ修正用
-- `experiment`: 実験的開発用（tmux統合）
-- `docs`: ドキュメント作成用
+Available templates:
+- `feature`: For new feature development (auto-start Claude Code)
+- `bugfix`: For bug fixes
+- `experiment`: For experimental development (tmux integration)
+- `docs`: For documentation creation
 
-## Draft PR機能
+## Draft PR Feature
 
-`--draft-pr` オプションを使用すると、演奏者作成と同時にGitHub上にDraft Pull Requestを作成します：
+Using the `--draft-pr` option creates a GitHub Draft Pull Request simultaneously with orchestra member creation:
 
 ```bash
 mst create feature/new-ui --draft-pr
 ```
 
-作成されるPRの内容：
-- タイトル: `[WIP] {ブランチ名}`
-- 本文: 開発中である旨と、Claude Code統合の説明
-- ステータス: Draft
-- ベースブランチ: 指定したベースブランチ（デフォルト: main）
+Created PR content:
+- Title: `[WIP] {branch-name}`
+- Body: Indicates work in progress and Claude Code integration explanation
+- Status: Draft
+- Base branch: Specified base branch (default: main)
 
-## Claude Code統合
+## Claude Code Integration
 
-`--claude` オプションを使用すると、演奏者作成後に自動的にClaude Codeが起動します：
+Using the `--claude` option automatically starts Claude Code after orchestra member creation:
 
 ```bash
 mst create feature/ai-feature --tmux --claude
 ```
 
-実行される処理：
-1. Worktreeの作成
-2. tmuxセッション/ウィンドウの作成
-3. Claude Codeの起動
-4. 初期コマンドの実行（設定で指定されている場合）
+Executed processes:
+1. Worktree creation
+2. tmux session/window creation
+3. Claude Code startup
+4. Initial command execution (if specified in configuration)
 
-## 設定ファイルとの連携
+## Configuration File Integration
 
-`.mst.json` の設定が自動的に適用されます：
+Settings from `.mst.json` are automatically applied:
 
 ```json
 {
@@ -143,67 +143,67 @@ mst create feature/ai-feature --tmux --claude
 
 ## Tips & Tricks
 
-### 1. ショートカットの活用
+### 1. Utilize Shortcuts
 
 ```bash
-# よく使う組み合わせはエイリアスにすると便利
+# Convenient to alias commonly used combinations
 alias mstf='mst create --tmux --claude --setup'
 
-# 使用例
+# Usage example
 mstf feature/new-feature
 ```
 
-### 2. Issue駆動開発
+### 2. Issue-Driven Development
 
 ```bash
-# Issueを確認
+# Check issues
 gh issue list
 
-# Issue番号で演奏者を作成
+# Create orchestra member by issue number
 mst create 123 --tmux --claude
 
-# 開発を開始
-# Issue情報は自動的にメタデータとして保存される
+# Start development
+# Issue information is automatically saved as metadata
 ```
 
-### 3. 並行開発フロー
+### 3. Parallel Development Flow
 
 ```bash
-# メイン機能の開発
+# Main feature development
 mst create feature/main-feature --tmux
 
-# サブ機能の開発（別ウィンドウ）
+# Sub-feature development (separate window)
 mst create feature/sub-feature --tmux --new-window
 
-# バグ修正（さらに別ウィンドウ）
+# Bug fix (yet another window)
 mst create bugfix/urgent-fix --tmux --new-window
 ```
 
-## エラーハンドリング
+## Error Handling
 
-### よくあるエラー
+### Common Errors
 
-1. **ブランチが既に存在する場合**
+1. **Branch already exists**
    ```
    Error: Branch 'feature/new-feature' already exists
    ```
-   解決方法: 別のブランチ名を使用するか、既存のブランチを削除してください
+   Solution: Use a different branch name or delete the existing branch
 
-2. **ベースブランチが存在しない場合**
+2. **Base branch not found**
    ```
    Error: Base branch 'develop' not found
    ```
-   解決方法: 存在するブランチを指定するか、`git fetch` を実行してください
+   Solution: Specify an existing branch or run `git fetch`
 
-3. **GitHub認証エラー**
+3. **GitHub authentication error**
    ```
    Error: GitHub authentication failed
    ```
-   解決方法: `gh auth login` でGitHub CLIの認証を行ってください
+   Solution: Authenticate GitHub CLI with `gh auth login`
 
-## 関連コマンド
+## Related Commands
 
-- [`mst list`](./list.md) - 作成した演奏者の一覧を表示
-- [`mst delete`](./delete.md) - 演奏者を削除
-- [`mst github`](./github.md) - GitHubのPR/Issueから演奏者を作成
-- [`mst template`](./template.md) - テンプレートの管理
+- [`mst list`](./list.md) - Display list of created orchestra members
+- [`mst delete`](./delete.md) - Delete orchestra members
+- [`mst github`](./github.md) - Create orchestra members from GitHub PR/Issues
+- [`mst template`](./template.md) - Template management

--- a/docs/commands/delete.md
+++ b/docs/commands/delete.md
@@ -1,56 +1,56 @@
 # mst delete
 
-演奏者（Git Worktree）を削除するコマンドです。不要になった演奏者をクリーンアップし、ディスク容量を解放します。
+Command to delete orchestra members (Git Worktrees). Cleans up unnecessary orchestra members and frees up disk space.
 
-## 概要
+## Overview
 
 ```bash
 mst delete <branch-name> [options]
-mst rm <branch-name> [options]  # エイリアス
+mst rm <branch-name> [options]  # alias
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# 演奏者を削除
+# Delete an orchestra member
 mst delete feature/old-feature
 
-# 強制削除（未コミットの変更があっても削除）
+# Force delete (delete even with uncommitted changes)
 mst delete feature/old-feature --force
 
-# fzfで選択して削除
+# Select and delete using fzf
 mst delete --fzf
 ```
 
-### 一括削除
+### Batch Deletion
 
 ```bash
-# マージ済みの演奏者を一括削除
+# Delete merged orchestra members in batch
 mst delete --merged
 
-# 30日以上古い演奏者を削除
+# Delete orchestra members older than 30 days
 mst delete --older-than 30
 
-# ドライラン（実際には削除しない）
+# Dry run (don't actually delete)
 mst delete --merged --dry-run
 ```
 
-## オプション
+## Options
 
-| オプション | 短縮形 | 説明 | デフォルト |
-|-----------|--------|------|-----------|
-| `--force` | `-f` | 強制削除（未コミットの変更を無視） | `false` |
-| `--fzf` | | fzfで選択して削除 | `false` |
-| `--merged` | `-m` | マージ済みの演奏者を削除 | `false` |
-| `--older-than <days>` | `-o` | 指定日数以上古い演奏者を削除 | なし |
-| `--dry-run` | `-n` | 実際には削除せず、削除対象を表示 | `false` |
-| `--yes` | `-y` | 確認プロンプトをスキップ | `false` |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--force` | `-f` | Force delete (ignore uncommitted changes) | `false` |
+| `--fzf` | | Select and delete using fzf | `false` |
+| `--merged` | `-m` | Delete merged orchestra members | `false` |
+| `--older-than <days>` | `-o` | Delete orchestra members older than specified days | none |
+| `--dry-run` | `-n` | Show deletion targets without actually deleting | `false` |
+| `--yes` | `-y` | Skip confirmation prompts | `false` |
 
-## 削除時の確認
+## Deletion Confirmation
 
-通常、削除前に確認プロンプトが表示されます：
+Normally, a confirmation prompt is displayed before deletion:
 
 ```
 🗑️  Are you sure you want to delete worktree 'feature/old-feature'?
@@ -63,71 +63,71 @@ mst delete --merged --dry-run
 ? Delete worktree? (y/N)
 ```
 
-## 安全な削除
+## Safe Deletion
 
-### 未コミットの変更がある場合
+### When There Are Uncommitted Changes
 
 ```bash
-# 通常の削除は失敗する
+# Normal deletion will fail
 mst delete feature/work-in-progress
 # Error: Worktree has uncommitted changes. Use --force to delete anyway.
 
-# 変更を確認
+# Check changes
 mst exec feature/work-in-progress git status
 
-# 変更を保存してから削除
+# Save changes before deletion
 mst exec feature/work-in-progress git stash
 mst delete feature/work-in-progress
 
-# または強制削除
+# Or force delete
 mst delete feature/work-in-progress --force
 ```
 
-### マージ済みブランチの確認
+### Checking Merged Branches
 
 ```bash
-# マージ済みの演奏者を確認
+# Check merged orchestra members
 mst delete --merged --dry-run
 
-# 出力例：
+# Example output:
 # Would delete the following merged worktrees:
 # - feature/completed-feature (merged to main)
 # - bugfix/fixed-bug (merged to main)
 # - feature/old-feature (merged to develop)
 
-# 実際に削除
+# Actually delete
 mst delete --merged --yes
 ```
 
-## 一括削除の活用
+## Utilizing Batch Deletion
 
-### 古い演奏者のクリーンアップ
+### Cleanup Old Orchestra Members
 
 ```bash
-# 60日以上更新されていない演奏者を確認
+# Check orchestra members not updated for 60+ days
 mst delete --older-than 60 --dry-run
 
-# 確認して削除
+# Confirm and delete
 mst delete --older-than 60
 ```
 
-### カスタム条件での削除
+### Deletion with Custom Conditions
 
 ```bash
-# 特定のプレフィックスを持つ演奏者を削除
+# Delete orchestra members with specific prefix
 mst list --json | jq -r '.worktrees[] | select(.branch | startswith("experiment/")) | .branch' | while read branch; do
   mst delete "$branch" --yes
 done
 
-# PR関連の演奏者でクローズ済みのものを削除
+# Delete PR-related orchestra members that are closed
 mst list --json | jq -r '.worktrees[] | select(.metadata.githubPR.state == "closed") | .branch' | while read branch; do
   mst delete "$branch"
 done
 ```
 
-## フック機能
+## Hook Feature
 
-`.mst.json` で削除前後のフックを設定できます：
+You can set hooks before and after deletion in `.mst.json`:
 
 ```json
 {
@@ -138,31 +138,31 @@ done
 }
 ```
 
-## エラーハンドリング
+## Error Handling
 
-### よくあるエラー
+### Common Errors
 
-1. **演奏者が見つからない場合**
+1. **Orchestra member not found**
    ```
    Error: Worktree 'feature/non-existent' not found
    ```
-   解決方法: `mst list` で正しいブランチ名を確認してください
+   Solution: Check the correct branch name with `mst list`
 
-2. **現在の演奏者を削除しようとした場合**
+2. **Attempting to delete current orchestra member**
    ```
    Error: Cannot delete the current worktree
    ```
-   解決方法: 別の演奏者に移動してから削除してください
+   Solution: Switch to another orchestra member before deletion
 
-3. **リモートブランチが残っている場合**
+3. **Remote branch still exists**
    ```
    Warning: Remote branch 'origin/feature/old-feature' still exists
    ```
-   対処方法: `git push origin --delete feature/old-feature` でリモートブランチも削除
+   Solution: Delete remote branch with `git push origin --delete feature/old-feature`
 
-## ベストプラクティス
+## Best Practices
 
-### 1. 定期的なクリーンアップ
+### 1. Regular Cleanup
 
 ```bash
 #!/bin/bash
@@ -170,84 +170,84 @@ done
 
 echo "🧹 Cleaning up worktrees..."
 
-# マージ済みを削除
+# Delete merged ones
 mst delete --merged --yes
 
-# 90日以上古いものを削除
+# Delete ones older than 90 days
 mst delete --older-than 90 --yes
 
-# 統計を表示
+# Display statistics
 echo "Remaining worktrees:"
 mst list | grep -c "^  "
 ```
 
-### 2. 削除前の確認フロー
+### 2. Pre-deletion Confirmation Flow
 
 ```bash
-# 削除対象の確認
+# Check deletion target
 BRANCH="feature/to-delete"
 
-# 1. 状態を確認
+# 1. Check status
 mst exec "$BRANCH" git status
 
-# 2. 最新のコミットを確認
+# 2. Check latest commits
 mst exec "$BRANCH" git log --oneline -5
 
-# 3. リモートとの差分を確認
+# 3. Check difference with remote
 mst exec "$BRANCH" git log origin/main..HEAD --oneline
 
-# 4. 問題なければ削除
+# 4. Delete if no issues
 mst delete "$BRANCH"
 ```
 
-### 3. 安全な削除エイリアス
+### 3. Safe Deletion Aliases
 
 ```bash
-# ~/.bashrc または ~/.zshrc に追加
+# Add to ~/.bashrc or ~/.zshrc
 alias mst-safe-delete='mst delete --dry-run'
 alias mst-cleanup='mst delete --merged --older-than 30'
 
-# 使用例
-mst-safe-delete feature/old  # 削除対象を確認
-mst-cleanup --yes            # 古い演奏者をクリーンアップ
+# Usage examples
+mst-safe-delete feature/old  # Check deletion targets
+mst-cleanup --yes            # Cleanup old orchestra members
 ```
 
 ## Tips & Tricks
 
-### リモートブランチも同時に削除
+### Delete Remote Branch Simultaneously
 
 ```bash
-# ローカルとリモートの両方を削除する関数
+# Function to delete both local and remote
 delete_worktree_and_remote() {
   local branch=$1
   
-  # ローカルの演奏者を削除
+  # Delete local orchestra member
   mst delete "$branch" --yes
   
-  # リモートブランチも削除
+  # Delete remote branch too
   git push origin --delete "$branch" 2>/dev/null || echo "Remote branch not found"
 }
 
-# 使用例
+# Usage example
 delete_worktree_and_remote feature/old-feature
 ```
 
-### 削除履歴の記録
+### Record Deletion History
 
 ```bash
-# 削除前に情報を記録
+# Record information before deletion
 mst list --json > worktrees-backup-$(date +%Y%m%d).json
 
-# 削除実行
+# Execute deletion
 mst delete feature/old-feature
 
-# 必要に応じて復元用の情報を参照
+# Reference restoration information if needed
 cat worktrees-backup-*.json | jq '.worktrees[] | select(.branch == "feature/old-feature")'
 ```
 
-## 関連コマンド
+## Related Commands
 
-- [`mst list`](./list.md) - 演奏者の一覧を表示
-- [`mst create`](./create.md) - 新しい演奏者を作成
-- [`mst health`](./health.md) - 演奏者の健全性をチェック
-- [`mst snapshot`](./snapshot.md) - 削除前にスナップショットを作成
+- [`mst list`](./list.md) - Display list of orchestra members
+- [`mst create`](./create.md) - Create new orchestra members
+- [`mst health`](./health.md) - Check orchestra member health
+- [`mst snapshot`](./snapshot.md) - Create snapshot before deletion

--- a/docs/commands/github.md
+++ b/docs/commands/github.md
@@ -1,84 +1,84 @@
 # mst github
 
-GitHub のIssueやPull Requestから直接演奏者（Git Worktree）を作成するコマンドです。GitHub CLIと連携して、開発フローをシームレスに統合します。
+Command to directly create orchestra members (Git Worktrees) from GitHub Issues or Pull Requests. Integrates with GitHub CLI to seamlessly integrate development workflows.
 
-## 概要
+## Overview
 
 ```bash
 mst github [pr|issue] [number] [options]
-mst gh [pr|issue] [number] [options]  # エイリアス
+mst gh [pr|issue] [number] [options]  # alias
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# Pull Requestから演奏者を作成
+# Create orchestra member from Pull Request
 mst github pr 123
 
-# Issueから演奏者を作成
+# Create orchestra member from Issue
 mst github issue 456
 
-# インタラクティブに選択
+# Interactive selection
 mst github
 ```
 
-### 高度な使用方法
+### Advanced Usage
 
 ```bash
-# PR作成と同時にClaude Codeを起動
+# Create PR and auto-start Claude Code
 mst github pr 123 --tmux --claude
 
-# 複数選択して一括作成
+# Multiple selection for batch creation
 mst github --multiple
 
-# フィルタリングして選択
+# Filtering for selection
 mst github issue --filter "label:bug"
 
-# 自分にアサインされたものだけ表示
+# Show only assigned to me
 mst github --assignee @me
 ```
 
-## オプション
+## Options
 
-| オプション | 短縮形 | 説明 | デフォルト |
-|-----------|--------|------|-----------|
-| `--tmux` | `-t` | tmuxセッション/ウィンドウを作成 | `false` |
-| `--claude` | `-c` | Claude Codeを自動起動 | `false` |
-| `--multiple` | `-m` | 複数選択モード | `false` |
-| `--filter <query>` | `-f` | GitHub CLIのフィルタクエリ | なし |
-| `--assignee <user>` | `-a` | 担当者でフィルタ（@meで自分） | なし |
-| `--limit <n>` | `-l` | 表示件数の上限 | `30` |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--tmux` | `-t` | Create tmux session/window | `false` |
+| `--claude` | `-c` | Auto-start Claude Code | `false` |
+| `--multiple` | `-m` | Multiple selection mode | `false` |
+| `--filter <query>` | `-f` | GitHub CLI filter query | none |
+| `--assignee <user>` | `-a` | Filter by assignee (@me for self) | none |
+| `--limit <n>` | `-l` | Limit of items to display | `30` |
 
-## Pull Requestからの作成
+## Creating from Pull Request
 
-### 基本フロー
+### Basic Flow
 
 ```bash
-# 1. PR一覧を確認
+# 1. Check PR list
 gh pr list
 
-# 2. PRから演奏者を作成
+# 2. Create orchestra member from PR
 mst github pr 123
 
-# 3. 作成された演奏者で作業
+# 3. Work in created orchestra member
 mst shell pr-123
 ```
 
-### 自動取得される情報
+### Automatically Retrieved Information
 
-- PRタイトル
-- PR説明文
-- 作成者情報
-- レビュアー
-- ラベル
-- マイルストーン
-- 関連Issue
-- ベースブランチ
-- マージ可能状態
+- PR title
+- PR description
+- Author information
+- Reviewers
+- Labels
+- Milestone
+- Related Issues
+- Base branch
+- Mergeable state
 
-### メタデータの保存
+### Metadata Storage
 
 ```json
 {
@@ -97,24 +97,24 @@ mst shell pr-123
 }
 ```
 
-## Issueからの作成
+## Creating from Issue
 
-### 基本フロー
+### Basic Flow
 
 ```bash
-# 1. Issue一覧を確認
+# 1. Check Issue list
 gh issue list
 
-# 2. Issueから演奏者を作成
+# 2. Create orchestra member from Issue
 mst github issue 456
 
-# 3. ブランチ名は自動生成
-# issue-456 として作成される
+# 3. Branch name is auto-generated
+# Created as issue-456
 ```
 
-### Issue番号の形式
+### Issue Number Formats
 
-以下のいずれの形式でも同じ結果になります：
+All of the following formats produce the same result:
 
 ```bash
 mst github issue 456
@@ -122,25 +122,25 @@ mst github issue #456
 mst github issue issue-456
 ```
 
-### 自動取得される情報
+### Automatically Retrieved Information
 
-- Issueタイトル
-- Issue本文
-- 作成者
-- 担当者
-- ラベル
-- マイルストーン
-- プロジェクト
-- 関連PR
+- Issue title
+- Issue body
+- Author
+- Assignees
+- Labels
+- Milestone
+- Projects
+- Related PRs
 
-## インタラクティブモード
+## Interactive Mode
 
 ```bash
-# メニューから選択
+# Select from menu
 mst github
 ```
 
-表示されるメニュー：
+Displayed menu:
 ```
 ? What would you like to create a worktree from?
 ❯ Pull Request
@@ -148,7 +148,7 @@ mst github
   Cancel
 ```
 
-その後、一覧から選択：
+Then select from list:
 ```
 ? Select a Pull Request:
 ❯ #125 feat: Add dark mode support (enhancement, ui)
@@ -157,47 +157,47 @@ mst github
   #122 refactor: Improve database queries (performance)
 ```
 
-## フィルタリング
+## Filtering
 
-GitHub CLIのフィルタ構文を使用できます：
+You can use GitHub CLI filter syntax:
 
-### Pull Requestのフィルタ
+### Pull Request Filters
 
 ```bash
-# ラベルでフィルタ
+# Filter by label
 mst github pr --filter "label:bug"
 
-# 状態でフィルタ
+# Filter by state
 mst github pr --filter "state:open draft:false"
 
-# 作成者でフィルタ
+# Filter by author
 mst github pr --filter "author:username"
 
-# 複合条件
+# Complex conditions
 mst github pr --filter "label:bug,critical state:open"
 ```
 
-### Issueのフィルタ
+### Issue Filters
 
 ```bash
-# 自分にアサインされたIssue
+# Issues assigned to me
 mst github issue --assignee @me
 
-# 特定のマイルストーン
+# Specific milestone
 mst github issue --filter "milestone:v2.0"
 
-# 最近更新されたもの
+# Recently updated
 mst github issue --filter "sort:updated-desc"
 ```
 
-## 複数選択モード
+## Multiple Selection Mode
 
 ```bash
-# 複数のPRを選択して一括作成
+# Select multiple PRs for batch creation
 mst github pr --multiple
 ```
 
-選択画面：
+Selection screen:
 ```
 ? Select Pull Requests: (Press <space> to select, <a> to toggle all)
  ◉ #125 feat: Add dark mode support
@@ -205,41 +205,41 @@ mst github pr --multiple
  ◉ #123 docs: Update API documentation
 ```
 
-## 統合ワークフロー
+## Integrated Workflows
 
-### レビューフロー
+### Review Flow
 
 ```bash
-# 1. レビュー待ちのPRを確認
+# 1. Check PRs awaiting review
 mst github pr --filter "review:required"
 
-# 2. PRから演奏者を作成してレビュー
+# 2. Create orchestra member from PR for review
 mst github pr 125 --tmux --claude
 
-# 3. AI差分レビューを実行
+# 3. Execute AI diff review
 mst suggest --review
 
-# 4. レビューコメントを投稿
+# 4. Post review comments
 gh pr review 125 --comment -b "LGTM with minor suggestions"
 ```
 
-### Issue駆動開発
+### Issue-Driven Development
 
 ```bash
-# 1. 優先度の高いIssueを選択
+# 1. Select high-priority Issues
 mst github issue --filter "label:priority:high"
 
-# 2. 演奏者を作成して開発開始
+# 2. Create orchestra member and start development
 mst github issue 456 --tmux --claude
 
-# 3. 開発完了後、PRを作成
+# 3. Create PR after development completion
 gh pr create --title "Fix #456: Authentication bug" --body "Closes #456"
 ```
 
-## CI/CD連携
+## CI/CD Integration
 
 ```bash
-# CIが失敗しているPRをローカルで検証
+# Verify failed PRs locally
 FAILED_PRS=$(gh pr list --json number,statusCheckRollup -q '.[] | select(.statusCheckRollup | length > 0) | select(.statusCheckRollup[0].state == "FAILURE") | .number')
 
 for pr in $FAILED_PRS; do
@@ -249,34 +249,34 @@ for pr in $FAILED_PRS; do
 done
 ```
 
-## エラーハンドリング
+## Error Handling
 
-### よくあるエラー
+### Common Errors
 
-1. **GitHub認証エラー**
+1. **GitHub authentication error**
    ```
    Error: GitHub authentication failed
    ```
-   解決方法: `gh auth login` でGitHub CLIの認証を行う
+   Solution: Authenticate GitHub CLI with `gh auth login`
 
-2. **PR/Issueが見つからない**
+2. **PR/Issue not found**
    ```
    Error: Pull request #999 not found
    ```
-   解決方法: 正しい番号を確認するか、リポジトリが正しいか確認
+   Solution: Check the correct number or verify the repository
 
-3. **既に演奏者が存在する**
+3. **Orchestra member already exists**
    ```
    Error: Worktree for PR #123 already exists
    ```
-   解決方法: 既存の演奏者を使用するか、削除してから再作成
+   Solution: Use existing orchestra member or delete and recreate
 
-## ベストプラクティス
+## Best Practices
 
-### 1. PR/Issue テンプレートの活用
+### 1. Utilizing PR/Issue Templates
 
 ```bash
-# PRテンプレートに基づいて自動的に開発環境を構築
+# Automatically build development environment based on PR template
 if [[ $(gh pr view 123 --json body -q '.body' | grep -c "Requires: tmux") -gt 0 ]]; then
   mst github pr 123 --tmux --claude
 else
@@ -284,10 +284,10 @@ else
 fi
 ```
 
-### 2. ラベルベースの自動化
+### 2. Label-Based Automation
 
 ```bash
-# ラベルに基づいて適切なテンプレートを使用
+# Use appropriate template based on labels
 PR_LABELS=$(gh pr view 123 --json labels -q '.labels[].name' | paste -sd,)
 
 if [[ $PR_LABELS == *"bug"* ]]; then
@@ -299,10 +299,10 @@ else
 fi
 ```
 
-### 3. 定期的な同期
+### 3. Regular Synchronization
 
 ```bash
-# 開いているPR/Issueの演奏者を最新状態に保つ
+# Keep orchestra members for open PR/Issues up to date
 mst list --json | jq -r '.worktrees[] | select(.metadata.githubPR != null) | .branch' | while read branch; do
   PR_NUM=$(echo $branch | grep -oE '[0-9]+')
   if [[ $(gh pr view $PR_NUM --json state -q '.state') == "OPEN" ]]; then
@@ -313,38 +313,38 @@ done
 
 ## Tips & Tricks
 
-### GitHub CLIエイリアス
+### GitHub CLI Aliases
 
 ```bash
-# ~/.config/gh/config.yml に追加
+# Add to ~/.config/gh/config.yml
 aliases:
   pr-worktree: "!mst github pr"
   issue-worktree: "!mst github issue"
 
-# 使用例
+# Usage examples
 gh pr-worktree 123
 gh issue-worktree 456
 ```
 
-### 自動ラベリング
+### Automatic Labeling
 
 ```bash
-# Issueから作成した演奏者にラベルを反映
+# Reflect labels from Issue to created orchestra member
 create_issue_worktree() {
   local issue=$1
   
-  # 演奏者を作成
+  # Create orchestra member
   mst github issue "$issue"
   
-  # Issueのラベルを取得してコミットメッセージに反映
+  # Get Issue labels and reflect in commit message
   LABELS=$(gh issue view "$issue" --json labels -q '.labels[].name' | paste -sd,)
   mst exec "issue-$issue" git commit --allow-empty -m "chore: start work on issue #$issue [$LABELS]"
 }
 ```
 
-## 関連コマンド
+## Related Commands
 
-- [`mst create`](./create.md) - 手動で演奏者を作成
-- [`mst batch`](./batch.md) - 複数のIssue/PRから一括作成
-- [`mst suggest`](./suggest.md) - PR作成時のメッセージ提案
-- [`mst review`](./review.md) - PRレビューフロー
+- [`mst create`](./create.md) - Manually create orchestra members
+- [`mst batch`](./batch.md) - Batch create from multiple Issues/PRs
+- [`mst suggest`](./suggest.md) - Message suggestions for PR creation
+- [`mst review`](./review.md) - PR review flow

--- a/docs/commands/health.md
+++ b/docs/commands/health.md
@@ -1,48 +1,48 @@
 # mst health
 
-演奏者（Git Worktree）の健全性をチェックし、問題を検出・修正するコマンドです。古い演奏者の検出、未コミット変更の確認、リモートブランチとの同期状態などを総合的に診断します。
+Command to check the health of orchestra members (Git Worktrees) and detect/fix issues. Comprehensively diagnoses old orchestra members detection, uncommitted changes verification, synchronization status with remote branches, and more.
 
-## 概要
+## Overview
 
 ```bash
 mst health [options]
-mst check [options]  # エイリアス
+mst check [options]  # alias
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# 全ての演奏者の健全性をチェック
+# Check health of all orchestra members
 mst health
 
-# 修正可能な問題を自動修正
+# Auto-fix fixable issues
 mst health --fix
 
-# 古い演奏者を削除（デフォルト: 30日以上）
+# Delete old orchestra members (default: 30+ days)
 mst health --prune
 
-# 詳細情報を表示
+# Display detailed information
 mst health --verbose
 ```
 
-## オプション
+## Options
 
-| オプション   | 短縮形 | 説明                         | デフォルト |
-| ------------ | ------ | ---------------------------- | ---------- |
-| `--fix`      | `-f`   | 修正可能な問題を自動修正     | `false`    |
-| `--prune`    | `-p`   | 古い演奏者を削除             | `false`    |
-| `--days <n>` | `-d`   | 古いと判定する日数           | `30`       |
-| `--verbose`  | `-v`   | 詳細情報を表示               | `false`    |
-| `--json`     | `-j`   | JSON形式で出力               | `false`    |
-| `--dry-run`  | `-n`   | 実際には修正せず、結果を表示 | `false`    |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--fix` | `-f` | Auto-fix fixable issues | `false` |
+| `--prune` | `-p` | Delete old orchestra members | `false` |
+| `--days <n>` | `-d` | Number of days to consider old | `30` |
+| `--verbose` | `-v` | Display detailed information | `false` |
+| `--json` | `-j` | Output in JSON format | `false` |
+| `--dry-run` | `-n` | Show results without actually fixing | `false` |
 
-## 検出される問題
+## Detected Issues
 
-### stale（古い演奏者）
+### stale (Old Orchestra Members)
 
-長期間更新されていない演奏者：
+Orchestra members not updated for a long time:
 
 ```
 ⚠️  stale: feature/old-feature
@@ -50,9 +50,9 @@ mst health --verbose
    Recommendation: Review and delete if no longer needed
 ```
 
-### orphaned（孤立した演奏者）
+### orphaned (Orphaned Orchestra Members)
 
-リモートブランチが存在しない演奏者：
+Orchestra members without remote branches:
 
 ```
 ❌ orphaned: feature/deleted-remote
@@ -60,9 +60,9 @@ mst health --verbose
    Recommendation: Delete worktree or push to remote
 ```
 
-### diverged（大きく乖離）
+### diverged (Heavily Diverged)
 
-メインブランチから大きく乖離した演奏者：
+Orchestra members heavily diverged from main branch:
 
 ```
 ⚠️  diverged: feature/long-running
@@ -71,9 +71,9 @@ mst health --verbose
    Recommendation: Rebase or merge with main branch
 ```
 
-### uncommitted（未コミット変更）
+### uncommitted (Uncommitted Changes)
 
-未コミットの変更がある演奏者：
+Orchestra members with uncommitted changes:
 
 ```
 ⚠️  uncommitted: feature/work-in-progress
@@ -82,9 +82,9 @@ mst health --verbose
    Recommendation: Commit or stash changes
 ```
 
-### conflict（マージ競合）
+### conflict (Merge Conflicts)
 
-マージ競合が未解決の演奏者：
+Orchestra members with unresolved merge conflicts:
 
 ```
 ❌ conflict: feature/merge-conflict
@@ -92,9 +92,9 @@ mst health --verbose
    Recommendation: Resolve conflicts and commit
 ```
 
-### missing（ディレクトリ不在）
+### missing (Directory Missing)
 
-ディレクトリが存在しない演奏者：
+Orchestra members with missing directories:
 
 ```
 ❌ missing: feature/moved-worktree
@@ -102,9 +102,9 @@ mst health --verbose
    Recommendation: Remove worktree entry
 ```
 
-## 出力形式
+## Output Formats
 
-### 通常の出力
+### Normal Output
 
 ```
 🏥 Orchestra Health Check
@@ -130,7 +130,7 @@ Run 'mst health --fix' to auto-fix some issues
 Run 'mst health --prune' to remove stale worktrees
 ```
 
-### JSON出力（`--json`）
+### JSON Output (`--json`)
 
 ```json
 {
@@ -186,47 +186,47 @@ Run 'mst health --prune' to remove stale worktrees
 }
 ```
 
-## 自動修正機能
+## Auto-Fix Feature
 
-`--fix` オプションで以下の問題を自動修正できます：
+The `--fix` option can automatically fix the following issues:
 
-### orphaned（孤立）の修正
+### Fixing orphaned Issues
 
 ```bash
 mst health --fix
 ```
 
-実行内容：
+Execution details:
 
-- リモートブランチが削除されている場合、ローカルのトラッキング情報を削除
-- 必要に応じて新しいリモートブランチを作成するか確認
+- Remove local tracking information when remote branch is deleted
+- Confirm whether to create new remote branch if needed
 
-### missing（ディレクトリ不在）の修正
+### Fixing missing (Directory Missing)
 
-自動的にWorktreeエントリを削除：
+Automatically remove Worktree entries:
 
 ```bash
 git worktree prune
 ```
 
-### 設定の不整合を修正
+### Fix Configuration Inconsistencies
 
-Worktree設定の不整合を検出して修正
+Detect and fix Worktree configuration inconsistencies
 
-## プルーニング（古い演奏者の削除）
+## Pruning (Deleting Old Orchestra Members)
 
 ```bash
-# 30日以上古い演奏者を確認
+# Check orchestra members older than 30 days
 mst health --prune --dry-run
 
-# 実際に削除
+# Actually delete
 mst health --prune
 
-# 60日以上に変更
+# Change to 60+ days
 mst health --prune --days 60
 ```
 
-プルーニング時の確認：
+Confirmation during pruning:
 
 ```
 The following stale worktrees will be deleted:
@@ -237,19 +237,19 @@ The following stale worktrees will be deleted:
 ? Proceed with deletion? (y/N)
 ```
 
-## 定期メンテナンス
+## Regular Maintenance
 
-### Cronジョブの設定
+### Cron Job Setup
 
 ```bash
-# 毎日午前9時に健全性チェック
+# Daily health check at 9 AM
 0 9 * * * cd /path/to/project && mst health --json > /tmp/mst-health.json
 
-# 週次で古い演奏者をクリーンアップ
+# Weekly cleanup of old orchestra members
 0 10 * * 1 cd /path/to/project && mst health --prune --days 30 --yes
 ```
 
-### CI/CDでの活用
+### CI/CD Usage
 
 ```yaml
 # .github/workflows/health-check.yml
@@ -257,7 +257,7 @@ name: Worktree Health Check
 
 on:
   schedule:
-    - cron: '0 0 * * *' # 毎日実行
+    - cron: '0 0 * * *' # Run daily
 
 jobs:
   health-check:
@@ -275,9 +275,9 @@ jobs:
           fi
 ```
 
-## カスタムチェック
+## Custom Checks
 
-### 健全性レポートの生成
+### Generating Health Reports
 
 ```bash
 #!/bin/bash
@@ -286,7 +286,7 @@ jobs:
 echo "# Worktree Health Report - $(date)"
 echo
 
-# 基本情報
+# Basic information
 echo "## Summary"
 mst health --json | jq -r '
   "- Total worktrees: \(.summary.total)",
@@ -297,7 +297,7 @@ mst health --json | jq -r '
 echo
 echo "## Detailed Issues"
 
-# 問題のある演奏者の詳細
+# Details of problematic orchestra members
 mst health --json | jq -r '
   .worktrees[] |
   select(.status != "healthy") |
@@ -308,24 +308,24 @@ mst health --json | jq -r '
 '
 ```
 
-### 問題別の対処
+### Handling by Issue Type
 
 ```bash
-# 未コミット変更がある演奏者を一括処理
+# Batch process orchestra members with uncommitted changes
 mst health --json | jq -r '.worktrees[] | select(.issues[].type == "uncommitted") | .branch' | while read branch; do
   echo "Processing $branch..."
   mst exec "$branch" git stash push -m "Auto-stash by health check"
 done
 
-# 孤立した演奏者を削除
+# Delete orphaned orchestra members
 mst health --json | jq -r '.worktrees[] | select(.issues[].type == "orphaned") | .branch' | while read branch; do
   mst delete "$branch" --force
 done
 ```
 
-## しきい値の設定
+## Setting Thresholds
 
-`.mst.json` で健全性チェックのしきい値を設定：
+Set health check thresholds in `.mst.json`:
 
 ```json
 {
@@ -347,26 +347,26 @@ done
 
 ## Tips & Tricks
 
-### 健全性スコアの算出
+### Calculating Health Score
 
 ```bash
-# 健全性スコアを計算（100点満点）
+# Calculate health score (out of 100)
 SCORE=$(mst health --json | jq '
   .summary.healthy / .summary.total * 100 | floor
 ')
 
 echo "Worktree health score: $SCORE/100"
 
-# 80点未満なら警告
+# Warn if below 80
 if [ $SCORE -lt 80 ]; then
   echo "⚠️  Health score is low. Run 'mst health --fix' to improve."
 fi
 ```
 
-### 問題の自動通知
+### Automatic Issue Notifications
 
 ```bash
-# Slack通知の例
+# Slack notification example
 ISSUES=$(mst health --json | jq '.summary.error + .summary.warning')
 
 if [ $ISSUES -gt 0 ]; then
@@ -376,10 +376,10 @@ if [ $ISSUES -gt 0 ]; then
 fi
 ```
 
-### インタラクティブ修正
+### Interactive Fixing
 
 ```bash
-# 問題を一つずつ確認して修正
+# Check and fix issues one by one
 mst health --json | jq -r '.worktrees[] | select(.status != "healthy") | .branch' | while read branch; do
   echo "=== $branch ==="
   mst health --verbose | grep -A5 "$branch"
@@ -387,15 +387,15 @@ mst health --json | jq -r '.worktrees[] | select(.status != "healthy") | .branch
   read -p "Fix this issue? (y/n) " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    # ここに修正ロジックを実装
+    # Implement fix logic here
     echo "Fixing $branch..."
   fi
 done
 ```
 
-## 関連コマンド
+## Related Commands
 
-- [`mst list`](./list.md) - 演奏者の一覧と状態を表示
-- [`mst delete`](./delete.md) - 問題のある演奏者を削除
-- [`mst sync`](./sync.md) - 乖離した演奏者を同期
-- [`mst snapshot`](./snapshot.md) - 修正前にスナップショットを作成
+- [`mst list`](./list.md) - Display list and status of orchestra members
+- [`mst delete`](./delete.md) - Delete problematic orchestra members
+- [`mst sync`](./sync.md) - Sync diverged orchestra members
+- [`mst snapshot`](./snapshot.md) - Create snapshot before fixing

--- a/docs/commands/history.md
+++ b/docs/commands/history.md
@@ -1,68 +1,68 @@
 # mst history
 
-Claude Code の会話履歴を管理するコマンドです。各演奏者（Git Worktree）での開発履歴を保存、検索、エクスポートできます。
+Command to manage Claude Code conversation history. Save, search, and export development history for each orchestra member (Git Worktree).
 
-## 概要
+## Overview
 
 ```bash
 mst history [options]
-mst h [options]  # エイリアス
+mst h [options]  # alias
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# 全ての履歴を一覧表示
+# List all histories
 mst history --list
 
-# 特定ブランチの履歴を表示
+# Show history for specific branch
 mst history --show feature-auth
 
-# 履歴をエクスポート
+# Export histories
 mst history --export all-histories.json
 mst history --export all-histories.md
 
-# 全履歴を1ファイルにマージ
+# Merge all histories into one file
 mst history --merge merged-history.md
 ```
 
-### 履歴管理
+### History Management
 
 ```bash
-# 不要な履歴をクリーンアップ
+# Cleanup unnecessary histories
 mst history --cleanup
 
-# 履歴パスを同期
+# Sync history paths
 mst history --sync
 
-# 履歴を検索
+# Search histories
 mst history --search "authentication"
 
-# JSON形式で出力
+# Output in JSON format
 mst history --list --json
 ```
 
-## オプション
+## Options
 
-| オプション         | 短縮形 | 説明                       | デフォルト |
-| ------------------ | ------ | -------------------------- | ---------- |
-| `--list`           | `-l`   | 履歴一覧を表示             | `false`    |
-| `--show <branch>`  | `-s`   | 特定ブランチの履歴を表示   | なし       |
-| `--export <file>`  | `-e`   | 履歴をエクスポート         | なし       |
-| `--merge <file>`   | `-m`   | 全履歴を1ファイルにマージ  | なし       |
-| `--cleanup`        | `-c`   | 不要な履歴をクリーンアップ | `false`    |
-| `--sync`           |        | 履歴パスを同期             | `false`    |
-| `--search <query>` |        | 履歴を検索                 | なし       |
-| `--json`           | `-j`   | JSON形式で出力             | `false`    |
-| `--days <n>`       | `-d`   | 指定日数以内の履歴のみ     | なし       |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--list` | `-l` | Display history list | `false` |
+| `--show <branch>` | `-s` | Show history for specific branch | none |
+| `--export <file>` | `-e` | Export histories | none |
+| `--merge <file>` | `-m` | Merge all histories into one file | none |
+| `--cleanup` | `-c` | Cleanup unnecessary histories | `false` |
+| `--sync` | | Sync history paths | `false` |
+| `--search <query>` | | Search histories | none |
+| `--json` | `-j` | Output in JSON format | `false` |
+| `--days <n>` | `-d` | Only histories within specified days | none |
 
-## 履歴の保存形式
+## History Storage Format
 
-Claude Code の履歴は以下の形式で保存されます：
+Claude Code history is stored in the following format:
 
-### ディレクトリ構造
+### Directory Structure
 
 ```
 ~/.claude/history/
@@ -72,7 +72,7 @@ Claude Code の履歴は以下の形式で保存されます：
 └── main.md
 ```
 
-### 履歴ファイルの内容
+### History File Content
 
 ```markdown
 # Claude Code History - feature/auth
@@ -81,11 +81,11 @@ Claude Code の履歴は以下の形式で保存されます：
 
 ### Human
 
-認証機能を実装してください。JWTを使用してください。
+Please implement authentication feature. Use JWT.
 
 ### Assistant
 
-認証機能をJWTで実装します。まず必要なパッケージをインストールしましょう...
+I'll implement authentication feature with JWT. First, let's install the required packages...
 
 ---
 
@@ -93,22 +93,22 @@ Claude Code の履歴は以下の形式で保存されます：
 
 ### Human
 
-テストを追加してください。
+Please add tests.
 
 ### Assistant
 
-認証機能のテストを追加します...
+I'll add tests for the authentication feature...
 ```
 
-## 履歴一覧の表示
+## Displaying History List
 
-### 通常の出力
+### Normal Output
 
 ```bash
 mst history --list
 ```
 
-出力例：
+Example output:
 
 ```
 📚 Claude Code Histories:
@@ -134,7 +134,7 @@ Summary:
 - Total tokens used: 43,700
 ```
 
-### JSON出力（`--json`）
+### JSON Output (`--json`)
 
 ```json
 {
@@ -161,52 +161,52 @@ Summary:
 }
 ```
 
-## 履歴の検索
+## Searching History
 
-### キーワード検索
+### Keyword Search
 
 ```bash
-# 特定のキーワードを含む履歴を検索
+# Search for histories containing specific keywords
 mst history --search "authentication"
 ```
 
-出力例：
+Example output:
 
 ```
 🔍 Search results for "authentication":
 
 feature/auth - Session 2025-01-20 10:30:00
-  Line 15: "認証機能を実装してください。JWTを使用してください。"
-  Line 20: "認証機能をJWTで実装します..."
+  Line 15: "Please implement authentication feature. Use JWT."
+  Line 20: "I'll implement authentication feature with JWT..."
 
 feature/api - Session 2025-01-19 15:00:00
-  Line 45: "APIの認証をOAuth2.0に変更..."
+  Line 45: "Change API authentication to OAuth2.0..."
 
 Found 2 matches in 2 worktrees
 ```
 
-### 高度な検索
+### Advanced Search
 
 ```bash
-# 正規表現を使用
+# Use regular expressions
 mst history --search "auth(entication|orization)" --regex
 
-# 期間を指定
+# Specify time period
 mst history --search "bug" --days 7
 
-# 特定のブランチ内で検索
+# Search within specific branch
 mst history --show feature-auth --search "JWT"
 ```
 
-## エクスポート機能
+## Export Feature
 
-### Markdown形式でエクスポート
+### Export in Markdown Format
 
 ```bash
 mst history --export all-histories.md
 ```
 
-生成されるファイル：
+Generated file:
 
 ```markdown
 # Maestro - Claude Code History Export
@@ -228,83 +228,83 @@ Export date: 2025-01-20 16:00:00
 ...
 ```
 
-### JSON形式でエクスポート
+### Export in JSON Format
 
 ```bash
 mst history --export all-histories.json
 ```
 
-### 特定期間のエクスポート
+### Export Specific Period
 
 ```bash
-# 過去7日間の履歴のみエクスポート
+# Export only histories from past 7 days
 mst history --export recent-history.md --days 7
 
-# 特定のブランチのみエクスポート
+# Export only specific branch
 mst history --show feature-auth --export feature-auth-history.md
 ```
 
-## マージ機能
+## Merge Feature
 
-複数の履歴ファイルを時系列で1つにマージ：
+Merge multiple history files chronologically into one:
 
 ```bash
 mst history --merge complete-history.md
 ```
 
-マージオプション：
+Merge options:
 
 ```bash
-# 重複を除外
+# Exclude duplicates
 mst history --merge complete-history.md --dedupe
 
-# タイムスタンプでソート
+# Sort by timestamp
 mst history --merge complete-history.md --sort-by-time
 
-# トークン数でソート（コスト分析用）
+# Sort by token count (for cost analysis)
 mst history --merge complete-history.md --sort-by-tokens
 ```
 
-## クリーンアップ
+## Cleanup
 
-### 古い履歴の削除
+### Delete Old Histories
 
 ```bash
-# 30日以上古い履歴を削除
+# Delete histories older than 30 days
 mst history --cleanup --days 30
 
-# 削除対象を確認（ドライラン）
+# Check deletion targets (dry run)
 mst history --cleanup --days 30 --dry-run
 ```
 
-### 孤立した履歴の削除
+### Delete Orphaned Histories
 
 ```bash
-# Worktreeが存在しない履歴を削除
+# Delete histories for non-existent worktrees
 mst history --cleanup --orphaned
 ```
 
-## 履歴の同期
+## History Sync
 
-### パスの同期
+### Path Synchronization
 
 ```bash
-# 履歴ファイルのパスを現在の設定に同期
+# Sync history file paths to current configuration
 mst history --sync
 ```
 
-これにより、設定ファイルで履歴パスを変更した場合でも、既存の履歴を新しい場所に移動できます。
+This allows moving existing histories to new locations when the history path is changed in configuration files.
 
-## 統計とレポート
+## Statistics and Reports
 
-### コスト分析
+### Cost Analysis
 
 ```bash
-# トークン使用量のレポート
+# Token usage report
 mst history --stats
 ```
 
-出力例：
+Example output:
 
 ```
 📊 Token Usage Report
@@ -324,16 +324,16 @@ Model Usage:
 - Claude 3 Sonnet: 13,700 tokens
 ```
 
-### 生産性分析
+### Productivity Analysis
 
 ```bash
-# セッション時間と頻度の分析
+# Analyze session time and frequency
 mst history --analyze
 ```
 
-## 設定
+## Configuration
 
-`.mst.json` で履歴管理をカスタマイズ：
+Customize history management in `.mst.json`:
 
 ```json
 {
@@ -348,26 +348,26 @@ mst history --analyze
 }
 ```
 
-## 高度な使用例
+## Advanced Usage Examples
 
-### 履歴からの学習
+### Learning from History
 
 ```bash
-# よく使うコマンドを抽出
+# Extract frequently used commands
 mst history --export - | grep -E "^### Human" -A1 | grep -v "^--" | sort | uniq -c | sort -nr | head -20
 ```
 
-### チーム共有
+### Team Sharing
 
 ```bash
-# 履歴を匿名化してエクスポート
+# Export history with anonymization
 mst history --export team-history.md --anonymize
 
-# 特定のセッションのみ共有
+# Share only specific session
 mst history --show feature-auth --session 2025-01-20 --export session.md
 ```
 
-### バックアップスクリプト
+### Backup Script
 
 ```bash
 #!/bin/bash
@@ -376,23 +376,23 @@ mst history --show feature-auth --session 2025-01-20 --export session.md
 BACKUP_DIR="./history-backups/$(date +%Y%m%d)"
 mkdir -p "$BACKUP_DIR"
 
-# 全履歴をバックアップ
+# Backup all histories
 mst history --export "$BACKUP_DIR/all-histories.json"
 mst history --merge "$BACKUP_DIR/merged-history.md"
 
-# 圧縮
+# Compress
 tar -czf "$BACKUP_DIR.tar.gz" "$BACKUP_DIR"
 rm -rf "$BACKUP_DIR"
 
 echo "Backup created: $BACKUP_DIR.tar.gz"
 ```
 
-## ベストプラクティス
+## Best Practices
 
-### 1. セッション管理
+### 1. Session Management
 
 ```bash
-# 新しいセッションを開始する前に履歴を確認
+# Check history before starting new session
 before_claude() {
   local branch=$(git branch --show-current)
   echo "📚 Previous sessions for $branch:"
@@ -400,10 +400,10 @@ before_claude() {
 }
 ```
 
-### 2. コスト最適化
+### 2. Cost Optimization
 
 ```bash
-# 高コストのセッションを特定
+# Identify high-cost sessions
 mst history --list --json | jq -r '
   .histories[] |
   select(.stats.tokens > 10000) |
@@ -411,10 +411,10 @@ mst history --list --json | jq -r '
 '
 ```
 
-### 3. 知識の継承
+### 3. Knowledge Inheritance
 
 ```bash
-# 有用なセッションをドキュメント化
+# Document useful sessions
 mst history --show feature-auth --export docs/auth-implementation.md
 echo "## Key Learnings" >> docs/auth-implementation.md
 echo "- JWT implementation details..." >> docs/auth-implementation.md
@@ -422,24 +422,24 @@ echo "- JWT implementation details..." >> docs/auth-implementation.md
 
 ## Tips & Tricks
 
-### 履歴エイリアス
+### History Aliases
 
 ```bash
-# ~/.bashrc または ~/.zshrc に追加
+# Add to ~/.bashrc or ~/.zshrc
 alias mst-history='mst history --list'
 alias mst-history-search='mst history --search'
 alias mst-history-export='mst history --export "histories-$(date +%Y%m%d).md"'
 
-# 使用例
-mst-history              # 履歴一覧
-mst-history-search bug   # バグ関連の履歴を検索
-mst-history-export       # 日付付きでエクスポート
+# Usage examples
+mst-history              # List histories
+mst-history-search bug   # Search bug-related histories
+mst-history-export       # Export with date
 ```
 
-### インテグレーション
+### Integration
 
 ```bash
-# Git フックで自動エクスポート
+# Auto-export with Git hooks
 cat > .git/hooks/pre-push << 'EOF'
 #!/bin/bash
 echo "Exporting Claude Code history..."
@@ -450,9 +450,9 @@ EOF
 chmod +x .git/hooks/pre-push
 ```
 
-## 関連コマンド
+## Related Commands
 
-- [`mst create`](./create.md) - 新しい演奏者と履歴を開始
-- [`mst suggest`](./suggest.md) - 履歴を基にした提案
-- [`mst snapshot`](./snapshot.md) - 履歴と併せてスナップショット管理
-- [`mst health`](./health.md) - 履歴ファイルの健全性チェック
+- [`mst create`](./create.md) - Start new orchestra member and history
+- [`mst suggest`](./suggest.md) - Suggestions based on history
+- [`mst snapshot`](./snapshot.md) - Snapshot management with history
+- [`mst health`](./health.md) - Health check for history files

--- a/docs/commands/snapshot.md
+++ b/docs/commands/snapshot.md
@@ -1,81 +1,81 @@
 # mst snapshot
 
-演奏者（Git Worktree）の現在の状態をスナップショットとして保存・復元するコマンドです。実験的な変更の前や、重要な作業の節目でバックアップを作成できます。
+Command to save and restore the current state of orchestra members (Git Worktrees) as snapshots. Create backups before experimental changes or at important work milestones.
 
-## 概要
+## Overview
 
 ```bash
 mst snapshot [options]
-mst snap [options]  # エイリアス
+mst snap [options]  # alias
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# 現在の演奏者のスナップショットを作成
+# Create snapshot of current orchestra member
 mst snapshot
 
-# メッセージ付きでスナップショット作成
-mst snapshot -m "機能実装前の状態"
+# Create snapshot with message
+mst snapshot -m "State before feature implementation"
 
-# 変更をスタッシュに保存してスナップショット作成
+# Save changes to stash and create snapshot
 mst snapshot --stash
 
-# 全ての演奏者のスナップショットを作成
+# Create snapshots of all orchestra members
 mst snapshot --all
 ```
 
-### スナップショット管理
+### Snapshot Management
 
 ```bash
-# スナップショット一覧を表示
+# Display snapshot list
 mst snapshot --list
 
-# JSON形式で一覧を表示
+# Display list in JSON format
 mst snapshot --list --json
 
-# スナップショットを復元
+# Restore snapshot
 mst snapshot --restore snapshot-20250120-103045
 
-# スナップショットを削除
+# Delete snapshot
 mst snapshot --delete snapshot-20250120-103045
 ```
 
-## オプション
+## Options
 
-| オプション        | 短縮形 | 説明                       | デフォルト |
-| ----------------- | ------ | -------------------------- | ---------- |
-| `--message <msg>` | `-m`   | スナップショットの説明     | なし       |
-| `--stash`         | `-s`   | 未コミット変更をスタッシュ | `false`    |
-| `--all`           | `-a`   | 全演奏者のスナップショット | `false`    |
-| `--list`          | `-l`   | スナップショット一覧を表示 | `false`    |
-| `--restore <id>`  | `-r`   | スナップショットを復元     | なし       |
-| `--delete <id>`   | `-d`   | スナップショットを削除     | なし       |
-| `--json`          | `-j`   | JSON形式で出力             | `false`    |
-| `--force`         | `-f`   | 確認なしで実行             | `false`    |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--message <msg>` | `-m` | Snapshot description | none |
+| `--stash` | `-s` | Stash uncommitted changes | `false` |
+| `--all` | `-a` | Snapshot all orchestra members | `false` |
+| `--list` | `-l` | Display snapshot list | `false` |
+| `--restore <id>` | `-r` | Restore snapshot | none |
+| `--delete <id>` | `-d` | Delete snapshot | none |
+| `--json` | `-j` | Output in JSON format | `false` |
+| `--force` | `-f` | Execute without confirmation | `false` |
 
-## スナップショットの内容
+## Snapshot Contents
 
-スナップショットには以下の情報が保存されます：
+Snapshots save the following information:
 
-- Git状態（ブランチ、HEAD、トラッキング情報）
-- コミット履歴（最新10件）
-- ステージング済みファイル
-- 変更ファイル
-- 未追跡ファイル
-- Worktreeメタデータ
-- スタッシュ（`--stash` オプション使用時）
+- Git state (branch, HEAD, tracking information)
+- Commit history (latest 10 commits)
+- Staged files
+- Modified files
+- Untracked files
+- Worktree metadata
+- Stash (when using `--stash` option)
 
-### スナップショットファイル形式
+### Snapshot File Format
 
 ```json
 {
   "id": "snapshot-20250120-103045",
   "worktree": "feature/auth",
   "timestamp": "2025-01-20T10:30:45Z",
-  "message": "機能実装前の状態",
+  "message": "State before feature implementation",
   "git": {
     "branch": "feature/auth",
     "head": "abc123def456",
@@ -103,30 +103,30 @@ mst snapshot --delete snapshot-20250120-103045
 }
 ```
 
-## スナップショット一覧
+## Snapshot List
 
-### 通常の出力
+### Normal Output
 
 ```bash
 mst snapshot --list
 ```
 
-出力例：
+Example output:
 
 ```
 📸 Snapshots:
 
 feature/auth:
-  • snapshot-20250120-103045 - "機能実装前の状態" (2 hours ago)
-  • snapshot-20250119-150000 - "バグ修正前" (1 day ago)
+  • snapshot-20250120-103045 - "State before feature implementation" (2 hours ago)
+  • snapshot-20250119-150000 - "Before bug fix" (1 day ago)
 
 bugfix/memory-leak:
-  • snapshot-20250120-090000 - "デバッグ開始前" (4 hours ago)
+  • snapshot-20250120-090000 - "Before debugging" (4 hours ago)
 
 Total: 3 snapshots across 2 worktrees
 ```
 
-### JSON出力（`--json`）
+### JSON Output (`--json`)
 
 ```json
 {
@@ -135,7 +135,7 @@ Total: 3 snapshots across 2 worktrees
       "id": "snapshot-20250120-103045",
       "worktree": "feature/auth",
       "timestamp": "2025-01-20T10:30:45Z",
-      "message": "機能実装前の状態",
+      "message": "State before feature implementation",
       "size": "2.3MB",
       "hasStash": false
     },
@@ -143,7 +143,7 @@ Total: 3 snapshots across 2 worktrees
       "id": "snapshot-20250119-150000",
       "worktree": "feature/auth",
       "timestamp": "2025-01-19T15:00:00Z",
-      "message": "バグ修正前",
+      "message": "Before bug fix",
       "size": "1.8MB",
       "hasStash": true
     }
@@ -156,78 +156,78 @@ Total: 3 snapshots across 2 worktrees
 }
 ```
 
-## スナップショットの復元
+## Snapshot Restoration
 
-### 基本的な復元
+### Basic Restoration
 
 ```bash
-# スナップショットIDを指定して復元
+# Restore by specifying snapshot ID
 mst snapshot --restore snapshot-20250120-103045
 ```
 
-復元プロセス：
+Restoration process:
 
-1. 現在の状態を一時保存
-2. HEADを指定されたコミットに移動
-3. ファイルの変更状態を復元
-4. スタッシュがあれば適用
+1. Temporarily save current state
+2. Move HEAD to specified commit
+3. Restore file change states
+4. Apply stash if exists
 
-### 復元時の確認
+### Restoration Confirmation
 
 ```
 🔄 Restoring snapshot: snapshot-20250120-103045
    Worktree: feature/auth
    Created: 2025-01-20 10:30:45
-   Message: "機能実装前の状態"
+   Message: "State before feature implementation"
 
 Current state will be backed up as: snapshot-20250120-140000-backup
 
 ? Proceed with restoration? (y/N)
 ```
 
-## 高度な使用例
+## Advanced Usage Examples
 
-### 実験的な変更の管理
+### Managing Experimental Changes
 
 ```bash
-# 1. 実験前にスナップショット作成
-mst snapshot -m "実験開始前の安定版"
+# 1. Create snapshot before experiment
+mst snapshot -m "Stable version before experiment"
 
-# 2. 実験的な変更を実施
-# ... コードの変更 ...
+# 2. Implement experimental changes
+# ... code changes ...
 
-# 3. 実験が失敗した場合、元に戻す
-mst snapshot --list  # IDを確認
+# 3. If experiment fails, revert to original
+mst snapshot --list  # Check ID
 mst snapshot --restore snapshot-20250120-103045
 
-# 4. 実験が成功した場合、新しいスナップショット作成
-mst snapshot -m "実験成功 - 新機能完成"
+# 4. If experiment succeeds, create new snapshot
+mst snapshot -m "Experiment successful - new feature complete"
 ```
 
-### 定期的なバックアップ
+### Regular Backups
 
 ```bash
 #!/bin/bash
 # daily-snapshot.sh
 
-# アクティブな演奏者のスナップショットを作成
+# Create snapshots for active orchestra members
 mst list --json | jq -r '.worktrees[] | select(.ahead > 0 or .behind > 0) | .branch' | while read branch; do
   echo "Creating snapshot for $branch..."
   mst exec "$branch" mst snapshot -m "Daily backup - $(date +%Y-%m-%d)"
 done
 ```
 
-### デプロイ前のチェックポイント
+### Pre-deployment Checkpoints
 
 ```bash
-# デプロイ前の状態を保存
+# Save state before deployment
 deploy_with_snapshot() {
   local branch=$1
 
-  # スナップショット作成
+  # Create snapshot
   mst exec "$branch" mst snapshot -m "Pre-deployment snapshot"
 
-  # デプロイ実行
+  # Execute deployment
   if ! deploy_script.sh; then
     echo "Deployment failed! Rolling back..."
     LATEST_SNAPSHOT=$(mst snapshot --list --json | jq -r '.snapshots[0].id')
@@ -239,21 +239,21 @@ deploy_with_snapshot() {
 }
 ```
 
-## スナップショットの管理
+## Snapshot Management
 
-### 古いスナップショットの削除
+### Delete Old Snapshots
 
 ```bash
-# 7日以上古いスナップショットを削除
+# Delete snapshots older than 7 days
 mst snapshot --list --json | jq -r '.snapshots[] | select(.timestamp < (now - 604800 | strftime("%Y-%m-%dT%H:%M:%SZ"))) | .id' | while read snapshot; do
   mst snapshot --delete "$snapshot"
 done
 ```
 
-### スナップショットのエクスポート
+### Export Snapshots
 
 ```bash
-# スナップショットをアーカイブとしてエクスポート
+# Export snapshot as archive
 SNAPSHOT_ID="snapshot-20250120-103045"
 EXPORT_DIR="./snapshot-exports"
 
@@ -261,28 +261,28 @@ mkdir -p "$EXPORT_DIR"
 mst snapshot --export "$SNAPSHOT_ID" --output "$EXPORT_DIR/$SNAPSHOT_ID.tar.gz"
 ```
 
-### スナップショットの比較
+### Compare Snapshots
 
 ```bash
-# 2つのスナップショット間の差分を表示
+# Display diff between two snapshots
 mst snapshot --diff snapshot-20250120-103045 snapshot-20250120-140000
 ```
 
-## ストレージ管理
+## Storage Management
 
-スナップショットは `.git/orchestrations/.snapshots/` に保存されます：
+Snapshots are stored in `.git/orchestrations/.snapshots/`:
 
 ```bash
-# ストレージ使用量を確認
+# Check storage usage
 du -sh .git/orchestrations/.snapshots/
 
-# 大きなスナップショットを検出
+# Detect large snapshots
 find .git/orchestrations/.snapshots/ -type f -size +10M -exec ls -lh {} \;
 ```
 
-## 設定
+## Configuration
 
-`.maestro.json` でスナップショットの動作をカスタマイズ：
+Customize snapshot behavior in `.maestro.json`:
 
 ```json
 {
@@ -296,21 +296,21 @@ find .git/orchestrations/.snapshots/ -type f -size +10M -exec ls -lh {} \;
 }
 ```
 
-## ベストプラクティス
+## Best Practices
 
-### 1. 命名規則
+### 1. Naming Convention
 
 ```bash
-# 一貫性のある命名規則を使用
-mst snapshot -m "feat: 認証機能実装前"
-mst snapshot -m "fix: メモリリーク修正前"
-mst snapshot -m "refactor: API構造変更前"
+# Use consistent naming convention
+mst snapshot -m "feat: before authentication implementation"
+mst snapshot -m "fix: before memory leak fix"
+mst snapshot -m "refactor: before API structure change"
 ```
 
-### 2. 重要な変更前の習慣化
+### 2. Habitualizing Before Important Changes
 
 ```bash
-# Git フックで自動化
+# Automate with Git hooks
 cat > .git/hooks/pre-rebase << 'EOF'
 #!/bin/bash
 echo "Creating snapshot before rebase..."
@@ -319,34 +319,34 @@ EOF
 chmod +x .git/hooks/pre-rebase
 ```
 
-### 3. チーム共有
+### 3. Team Sharing
 
 ```bash
-# スナップショットをチームで共有
+# Share snapshot with team
 mst snapshot --export snapshot-20250120-103045 --share
 
-# 共有されたスナップショットをインポート
+# Import shared snapshot
 mst snapshot --import shared-snapshot-20250120-103045.tar.gz
 ```
 
 ## Tips & Tricks
 
-### スナップショットエイリアス
+### Snapshot Aliases
 
 ```bash
-# ~/.bashrc または ~/.zshrc に追加
+# Add to ~/.bashrc or ~/.zshrc
 alias mst-backup='mst snapshot -m "Quick backup - $(date +%Y-%m-%d_%H:%M)"'
 alias mst-restore-latest='mst snapshot --restore $(mst snapshot --list --json | jq -r ".snapshots[0].id")'
 
-# 使用例
-mst-backup          # 素早くバックアップ
-mst-restore-latest  # 最新のスナップショットに復元
+# Usage examples
+mst-backup          # Quick backup
+mst-restore-latest  # Restore to latest snapshot
 ```
 
-### スナップショット統計
+### Snapshot Statistics
 
 ```bash
-# スナップショット統計を表示
+# Display snapshot statistics
 mst snapshot --list --json | jq '
   {
     total: .summary.total,
@@ -361,9 +361,9 @@ mst snapshot --list --json | jq '
 '
 ```
 
-## 関連コマンド
+## Related Commands
 
-- [`mst list`](./list.md) - スナップショットを作成する演奏者を確認
-- [`mst health`](./health.md) - スナップショット前に健全性をチェック
-- [`mst sync`](./sync.md) - スナップショット後に同期
-- [`mst history`](./history.md) - Claude Code履歴と併せて管理
+- [`mst list`](./list.md) - Check orchestra members to snapshot
+- [`mst health`](./health.md) - Check health before snapshot
+- [`mst sync`](./sync.md) - Sync after snapshot
+- [`mst history`](./history.md) - Manage with Claude Code history

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -1,91 +1,91 @@
 # mst sync
 
-演奏者（Git Worktree）間でコードや設定ファイルを同期するコマンドです。メインブランチの変更を他の演奏者に反映したり、環境設定ファイルを共有したりできます。
+Command to synchronize code and configuration files between orchestra members (Git Worktrees). Sync changes from main branch to other orchestra members or share configuration files.
 
-## 概要
+## Overview
 
 ```bash
 mst sync [branch-name] [options]
-mst s [branch-name] [options]  # エイリアス
+mst s [branch-name] [options]  # alias
 ```
 
-## 使用例
+## Usage Examples
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# メインブランチの変更を特定の演奏者に同期
+# Sync main branch changes to specific orchestra member
 mst sync feature-branch
 
-# 全ての演奏者に同期
+# Sync to all orchestra members
 mst sync --all
 
-# インタラクティブに選択
+# Interactive selection
 mst sync
 
-# rebaseで同期（デフォルトはmerge）
+# Sync with rebase (default is merge)
 mst sync --rebase
 ```
 
-### ファイル同期
+### File Synchronization
 
 ```bash
-# 環境変数・設定ファイルを同期
+# Sync environment/config files
 mst sync --files
 
-# プリセットを使用してファイル同期
-mst sync --preset env     # .env系ファイルのみ
-mst sync --preset config  # 設定ファイルのみ
-mst sync --preset all     # 全ての設定ファイル
+# Use preset for file sync
+mst sync --preset env     # .env files only
+mst sync --preset config  # config files only
+mst sync --preset all     # all config files
 
-# カスタムファイルを指定して同期
+# Sync custom specified files
 mst sync --files --custom .env.local,config/app.json
 
-# インタラクティブにファイルを選択
+# Interactive file selection
 mst sync --interactive
 ```
 
-## オプション
+## Options
 
-| オプション | 短縮形 | 説明 | デフォルト |
-|-----------|--------|------|-----------|
-| `--all` | `-a` | 全ての演奏者に同期 | `false` |
-| `--rebase` | `-r` | rebaseで同期（デフォルトはmerge） | `false` |
-| `--files` | `-f` | ファイル同期モード | `false` |
-| `--preset <name>` | `-p` | プリセットを使用 | なし |
-| `--custom <files>` | `-c` | カスタムファイルリスト（カンマ区切り） | なし |
-| `--interactive` | `-i` | インタラクティブモード | `false` |
-| `--force` | | 競合を無視して強制同期 | `false` |
-| `--dry-run` | `-n` | 実際には同期せず、変更内容を表示 | `false` |
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--all` | `-a` | Sync to all orchestra members | `false` |
+| `--rebase` | `-r` | Sync with rebase (default is merge) | `false` |
+| `--files` | `-f` | File sync mode | `false` |
+| `--preset <name>` | `-p` | Use preset | none |
+| `--custom <files>` | `-c` | Custom file list (comma-separated) | none |
+| `--interactive` | `-i` | Interactive mode | `false` |
+| `--force` | | Force sync ignoring conflicts | `false` |
+| `--dry-run` | `-n` | Show changes without actually syncing | `false` |
 
-## 同期モード
+## Sync Modes
 
-### コード同期（デフォルト）
+### Code Sync (Default)
 
-メインブランチ（または指定したベースブランチ）の最新の変更を演奏者に取り込みます：
+Incorporates latest changes from main branch (or specified base branch) into orchestra members:
 
 ```bash
-# merge方式（デフォルト）
+# merge method (default)
 mst sync feature-branch
-# 実行内容: git merge origin/main
+# Executes: git merge origin/main
 
-# rebase方式
+# rebase method
 mst sync feature-branch --rebase
-# 実行内容: git rebase origin/main
+# Executes: git rebase origin/main
 
-# 全演奏者に適用
+# Apply to all orchestra members
 mst sync --all --rebase
 ```
 
-### ファイル同期
+### File Sync
 
-設定ファイルや環境変数ファイルを演奏者間で共有します：
+Share configuration files and environment variable files between orchestra members:
 
 ```bash
-# 基本的なファイル同期
+# Basic file sync
 mst sync --files
 
-# 同期されるファイル（デフォルト）:
+# Files synced by default:
 # - .env
 # - .env.local
 # - .env.development
@@ -94,31 +94,31 @@ mst sync --files
 # - config/*.yml
 ```
 
-## プリセット
+## Presets
 
-### env プリセット
+### env Preset
 
-環境変数ファイルのみを同期：
+Sync environment variable files only:
 
 ```bash
 mst sync --preset env
 ```
 
-同期対象:
+Sync targets:
 - `.env`
 - `.env.*`
 - `config/.env`
 - `config/.env.*`
 
-### config プリセット
+### config Preset
 
-設定ファイルのみを同期：
+Sync configuration files only:
 
 ```bash
 mst sync --preset config
 ```
 
-同期対象:
+Sync targets:
 - `config/*.json`
 - `config/*.yml`
 - `config/*.yaml`
@@ -126,31 +126,31 @@ mst sync --preset config
 - `.prettierrc*`
 - `tsconfig*.json`
 
-### all プリセット
+### all Preset
 
-全ての設定ファイルを同期：
+Sync all configuration files:
 
 ```bash
 mst sync --preset all
 ```
 
-同期対象:
-- envプリセットの全ファイル
-- configプリセットの全ファイル
+Sync targets:
+- All files from env preset
+- All files from config preset
 - `package.json`
 - `package-lock.json`
 - `pnpm-lock.yaml`
 - `yarn.lock`
 
-## インタラクティブモード
+## Interactive Mode
 
-ファイルを個別に選択して同期：
+Select and sync files individually:
 
 ```bash
 mst sync --interactive
 ```
 
-表示例：
+Example display:
 ```
 ? Select files to sync: (Press <space> to select, <a> to toggle all)
  ◉ .env
@@ -160,63 +160,63 @@ mst sync --interactive
  ◉ tsconfig.json
 ```
 
-## 同期の流れ
+## Sync Flow
 
-### コード同期の詳細
+### Code Sync Details
 
-1. **事前確認**
+1. **Pre-check**
    ```bash
-   # ドライランで確認
+   # Check with dry run
    mst sync feature-branch --dry-run
    ```
 
-2. **同期実行**
+2. **Execute sync**
    ```bash
-   # 実際に同期
+   # Actually sync
    mst sync feature-branch
    ```
 
-3. **競合解決**
+3. **Conflict resolution**
    ```bash
-   # 競合が発生した場合
-   # 1. 手動で解決
+   # When conflicts occur
+   # 1. Resolve manually
    mst shell feature-branch
-   # エディタで競合を解決
+   # Resolve conflicts in editor
    
-   # 2. 解決をコミット
+   # 2. Commit resolution
    git add .
    git commit -m "resolve: merge conflicts"
    ```
 
-### ファイル同期の詳細
+### File Sync Details
 
-1. **差分確認**
+1. **Check differences**
    ```bash
-   # どのファイルが同期されるか確認
+   # Check which files will be synced
    mst sync --files --dry-run
    ```
 
-2. **同期実行**
+2. **Execute sync**
    ```bash
-   # メインブランチから全演奏者へ
+   # From main branch to all orchestra members
    mst sync --all --files
    ```
 
-3. **カスタム同期**
+3. **Custom sync**
    ```bash
-   # 特定のファイルのみ
+   # Specific files only
    mst sync --files --custom .env.production,config/secrets.json
    ```
 
-## 高度な使用例
+## Advanced Usage Examples
 
-### CI/CD設定の同期
+### CI/CD Configuration Sync
 
 ```bash
-# CI設定を全演奏者に反映
+# Apply CI config to all orchestra members
 mst sync --all --files --custom .github/workflows/ci.yml,.gitlab-ci.yml
 
-# または専用スクリプト
+# Or dedicated script
 cat > sync-ci.sh << 'EOF'
 #!/bin/bash
 CI_FILES=".github/workflows/*.yml,.gitlab-ci.yml,Jenkinsfile"
@@ -225,48 +225,48 @@ EOF
 chmod +x sync-ci.sh
 ```
 
-### 選択的同期
+### Selective Sync
 
 ```bash
-# 特定のパターンに一致する演奏者のみ同期
+# Sync only orchestra members matching specific pattern
 mst list --json | jq -r '.worktrees[] | select(.branch | startswith("feature/")) | .branch' | while read branch; do
   echo "Syncing $branch..."
   mst sync "$branch" --rebase
 done
 ```
 
-### 同期状態の確認
+### Check Sync Status
 
 ```bash
-# 各演奏者の同期状態を確認
+# Check sync status of each orchestra member
 mst list --json | jq -r '.worktrees[] | "\(.branch): \(.behind) commits behind"' | grep -v ": 0 commits"
 ```
 
-## エラーハンドリング
+## Error Handling
 
-### よくあるエラー
+### Common Errors
 
-1. **マージ競合**
+1. **Merge conflicts**
    ```
    Error: Merge conflict in files: src/index.js, src/utils.js
    ```
-   解決方法: 演奏者に移動して手動で競合を解決
+   Solution: Move to orchestra member and resolve conflicts manually
 
-2. **未コミットの変更**
+2. **Uncommitted changes**
    ```
    Error: Worktree has uncommitted changes
    ```
-   解決方法: 変更をコミットまたはスタッシュしてから再実行
+   Solution: Commit or stash changes before re-executing
 
-3. **ファイルが見つからない**
+3. **File not found**
    ```
    Warning: File '.env.local' not found in source worktree
    ```
-   対処方法: ファイルが存在することを確認するか、別のファイルを指定
+   Solution: Verify file exists or specify different file
 
-## ベストプラクティス
+## Best Practices
 
-### 1. 定期的な同期
+### 1. Regular Sync
 
 ```bash
 #!/bin/bash
@@ -274,29 +274,29 @@ mst list --json | jq -r '.worktrees[] | "\(.branch): \(.behind) commits behind"'
 
 echo "🔄 Daily sync starting..."
 
-# 1. 最新のmainを取得
+# 1. Fetch latest main
 git fetch origin main
 
-# 2. 全演奏者をrebaseで同期
+# 2. Sync all orchestra members with rebase
 mst sync --all --rebase
 
-# 3. 環境ファイルも同期
+# 3. Sync environment files too
 mst sync --all --preset env
 
 echo "✅ Sync completed"
 ```
 
-### 2. 同期前のバックアップ
+### 2. Backup Before Sync
 
 ```bash
-# スナップショットを作成してから同期
+# Create snapshot before sync
 mst snapshot --all -m "Before sync"
 mst sync --all --rebase
 ```
 
-### 3. プロジェクト固有の設定
+### 3. Project-specific Configuration
 
-`.maestro.json` で同期設定をカスタマイズ：
+Customize sync settings in `.maestro.json`:
 
 ```json
 {
@@ -316,23 +316,23 @@ mst sync --all --rebase
 
 ## Tips & Tricks
 
-### 同期エイリアス
+### Sync Aliases
 
 ```bash
-# ~/.bashrc または ~/.zshrc に追加
+# Add to ~/.bashrc or ~/.zshrc
 alias mst-sync-all='mst sync --all --rebase'
 alias mst-sync-env='mst sync --all --preset env'
 alias mst-sync-safe='mst sync --dry-run'
 
-# 使用例
-mst-sync-all    # 全演奏者をrebase同期
-mst-sync-env    # 環境ファイルを同期
+# Usage examples
+mst-sync-all    # Rebase sync all orchestra members
+mst-sync-env    # Sync environment files
 ```
 
-### 条件付き同期
+### Conditional Sync
 
 ```bash
-# テストが通った場合のみ同期
+# Sync only if tests pass
 sync_if_tests_pass() {
   local branch=$1
   
@@ -343,13 +343,13 @@ sync_if_tests_pass() {
   fi
 }
 
-# 使用例
+# Usage example
 sync_if_tests_pass feature-branch
 ```
 
-## 関連コマンド
+## Related Commands
 
-- [`mst list`](./list.md) - 同期が必要な演奏者を確認
-- [`mst health`](./health.md) - 同期状態の健全性をチェック
-- [`mst snapshot`](./snapshot.md) - 同期前にスナップショットを作成
-- [`mst watch`](./watch.md) - ファイル変更を自動同期
+- [`mst list`](./list.md) - Check orchestra members needing sync
+- [`mst health`](./health.md) - Check sync status health
+- [`mst snapshot`](./snapshot.md) - Create snapshot before sync
+- [`mst watch`](./watch.md) - Auto-sync file changes


### PR DESCRIPTION
## Summary
- Translated all 8 Japanese documentation files in `docs/commands/` to English
- Maintained exact same structure and technical accuracy as originals
- Followed consistent English style matching existing `list.md` documentation
- All commands, code examples, and option tables preserved exactly

## Translated Files
- `batch.md` - Batch creation and management of multiple worktrees
- `create.md` - Creating single worktrees with various options  
- `delete.md` - Deleting worktrees with safety checks and cleanup
- `github.md` - GitHub PR/Issue integration for worktree creation
- `health.md` - Health checking and maintenance of worktrees
- `history.md` - Claude Code conversation history management
- `snapshot.md` - Snapshot save/restore functionality for worktrees
- `sync.md` - Code and file synchronization between worktrees

## Test plan
- [x] Verify all markdown renders correctly
- [x] Check that all internal links still work properly
- [x] Confirm code examples and command syntax remain accurate
- [x] Validate option tables and technical details are preserved

🤖 Generated with [Claude Code](https://claude.ai/code)