### PR TITLE
update: change GitHub username from hashiramaendure to camoneart

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "hashiramaendure/maestro" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "camoneart/maestro" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           echo "⚠️  Codecov token not available - skipping coverage upload"
           echo "To enable coverage reporting, add CODECOV_TOKEN to repository secrets"
-          echo "Visit: https://app.codecov.io/github/hashiramaendure/maestro"
+          echo "Visit: https://app.codecov.io/github/camoneart/maestro"
 
       - name: Upload coverage reports
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20' && github.event_name == 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### Minor Changes
 
-- [#36](https://github.com/hashiramaendure/maestro/pull/36) [`2f43ca5`](https://github.com/hashiramaendure/maestro/commit/2f43ca554aeee7d112779e77e2f814ab92e67006) Thanks [@hashiramaendure](https://github.com/hashiramaendure)! - Add new options to create command and implement attach command
+- [#36](https://github.com/camoneart/maestro/pull/36) [`2f43ca5`](https://github.com/camoneart/maestro/commit/2f43ca554aeee7d112779e77e2f814ab92e67006) Thanks [@camoneart](https://github.com/camoneart)! - Add new options to create command and implement attach command
   - Add `--shell` option to create command: enter shell after creating worktree
   - Add `--exec <command>` option to create command: execute command after creating worktree
   - Add `--copy-file <file>` option to create command: copy files from current worktree
@@ -45,7 +45,7 @@
 
 ### Patch Changes
 
-- [`4280a19`](https://github.com/hashiramaendure/maestro/commit/4280a19) Thanks [@hashiramaendure](https://github.com/hashiramaendure)! - fix: resolve worktree branch name matching in delete command
+- [`4280a19`](https://github.com/camoneart/maestro/commit/4280a19) Thanks [@camoneart](https://github.com/camoneart)! - fix: resolve worktree branch name matching in delete command
 
   Fixed an issue where the `mst delete` command would fail with "ワークツリー 'refs/heads/branch-name' が見つかりません" error. The issue occurred because the delete command was passing branch names with the `refs/heads/` prefix to the GitWorktreeManager, which expects clean branch names.
 
@@ -53,7 +53,7 @@
 
 ### Minor Changes
 
-- [`7a3c70d`](https://github.com/hashiramaendure/maestro/commit/7a3c70d6f76aaa5c9ef103b2973622ff7235a89e) Thanks [@hashiramaendure](https://github.com/hashiramaendure)! - feat: Add tmux pane split functionality
+- [`7a3c70d`](https://github.com/camoneart/maestro/commit/7a3c70d6f76aaa5c9ef103b2973622ff7235a89e) Thanks [@camoneart](https://github.com/camoneart)! - feat: Add tmux pane split functionality
   - Add `--tmux-h` option for horizontal pane split (side by side)
   - Add `--tmux-v` option for vertical pane split (top and bottom)
   - Automatically execute Claude commands in new panes when `--claude` is used
@@ -66,7 +66,7 @@
 
 ### Patch Changes
 
-- [`ed0a0ff`](https://github.com/hashiramaendure/maestro/commit/ed0a0ff2fc1b97f3e2a8f8a7f0a62a1d5937ecff) Thanks [@hashiramaendure](https://github.com/hashiramaendure)! - feat(list): Add relative path display for better readability
+- [`ed0a0ff`](https://github.com/camoneart/maestro/commit/ed0a0ff2fc1b97f3e2a8f8a7f0a62a1d5937ecff) Thanks [@camoneart](https://github.com/camoneart)! - feat(list): Add relative path display for better readability
   - Display worktree paths relative to repository root by default
   - Add `--full-path` option to show absolute paths when needed
   - Current directory shows as `.` for clarity
@@ -105,7 +105,7 @@
   ## 🚨 Breaking Changes
 
   ### Package & Command Changes
-  - **Package name**: `shadow-clone-jutsu` → `@hashiramaendure/maestro`
+  - **Package name**: `shadow-clone-jutsu` → `@camoneart/maestro`
   - **Command**: `scj` → `maestro` (or `mst` for short)
   - **Configuration file**: `.scj.json` → `.maestro.json`
   - **Default directory**: `.git/shadow-clones` → `.git/orchestrations`
@@ -126,7 +126,7 @@
      ```
   2. **Install new package**:
      ```bash
-     npm install -g @hashiramaendure/maestro
+     npm install -g @camoneart/maestro
      ```
   3. **Update configuration**:
      - Rename `.scj.json` to `.maestro.json`
@@ -147,7 +147,7 @@
 
   ***
 
-  For more details, see the [migration guide](https://github.com/hashiramaendure/maestro/wiki/migration-guide).
+  For more details, see the [migration guide](https://github.com/camoneart/maestro/wiki/migration-guide).
 
 All notable changes to this project will be documented in this file.
 
@@ -159,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: Rebranded from "shadow-clone-jutsu" to "Maestro" with conductor/orchestra theme
-- **BREAKING**: Changed package name from `shadow-clone-jutsu` to `@hashiramaendure/maestro`
+- **BREAKING**: Changed package name from `shadow-clone-jutsu` to `@camoneart/maestro`
 - **BREAKING**: Changed CLI command from `scj` to `maestro` (alias: `mst`), keeping `scj` for backward compatibility
 - **BREAKING**: Changed configuration file from `.scj.json` to `.maestro.json` (with fallback support)
 - **BREAKING**: Changed default worktree directory from `.git/shadow-clones` to `.git/orchestrations`
@@ -176,7 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Patch Changes
 
-- [`4fcf9d1`](https://github.com/hashiramaendure/maestro/commit/4fcf9d1740864bc7d860cf32650cafde36f742e3) Thanks [@hashiramaendure](https://github.com/hashiramaendure)! - Test automatic versioning and release workflow setup
+- [`4fcf9d1`](https://github.com/camoneart/maestro/commit/4fcf9d1740864bc7d860cf32650cafde36f742e3) Thanks [@camoneart](https://github.com/camoneart)! - Test automatic versioning and release workflow setup
 
 ## [1.0.0] - 2025-07-15
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 本プロジェクトは [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) に従います。
 
-違反報告は hashiramaendure@gmail.com までご連絡ください。
+違反報告は camoneart@gmail.com までご連絡ください。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This project and everyone participating in it is governed by our Code of Conduct
 
 1. Fork the repository
 2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/maestro.git`
-3. Add upstream remote: `git remote add upstream https://github.com/hashiramaendure/maestro.git`
+3. Add upstream remote: `git remote add upstream https://github.com/camoneart/maestro.git`
 4. Create a new branch: `git checkout -b feature/your-feature-name`
 
 ## Development Setup

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 hashiramaendure
+Copyright (c) 2025 camoneart
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 # Maestro
 
 [![Node.js >=20.0.0](https://img.shields.io/badge/Node.js-%3E%3D20.0.0-45CC11?labelColor=555555&style=flat&logoColor=FFFFFF)](https://nodejs.org/)
-[![npm version](https://img.shields.io/npm/v/@hashiramaendure/maestro?color=007EC5&labelColor=555555&style=flat&logoColor=FFFFFF)](https://www.npmjs.com/package/@hashiramaendure/maestro)
+[![npm version](https://img.shields.io/npm/v/@camoneart/maestro?color=007EC5&labelColor=555555&style=flat&logoColor=FFFFFF)](https://www.npmjs.com/package/@camoneart/maestro)
 [![License MIT](https://img.shields.io/badge/License-MIT-yellow?labelColor=555555&style=flat)](https://opensource.org/licenses/MIT)
 
 ![maestro](public/image/logo/maestro-logo.png)
@@ -54,7 +54,7 @@ Maestroは、Git Worktreeをより直感的に管理できるCLIツールです�
 ### Homebrew を使用 (推奨)
 
 ```bash
-brew install hashiramaendure/tap/maestro
+brew install camoneart/tap/maestro
 ```
 
 ※ Homebrew でインストールすると、zsh / fish / Bash すべての補完スクリプトが自動で配置されます。<br>
@@ -63,21 +63,21 @@ brew install hashiramaendure/tap/maestro
 ### npm を使用
 
 ```bash
-npm install -g @hashiramaendure/maestro
+npm install -g @camoneart/maestro
 ```
 
 ### pnpm を使用
 
 ```bash
 # pnpm が入っていない場合は最初に: npm install -g pnpm
-pnpm add -g @hashiramaendure/maestro
+pnpm add -g @camoneart/maestro
 ```
 
 ## クイックスタート
 
 ```bash
 # 1. インストール  ※Homebrew 例
-brew install hashiramaendure/tap/maestro
+brew install camoneart/tap/maestro
 
 # 2. Git プロジェクトに移動
 cd ~/path/to/your-repo
@@ -265,7 +265,7 @@ mst completion fish > ~/.config/fish/completions/mst.fish
 | `EADDRINUSE` | MCP サーバーのポート競合       | `mst mcp stop` で既存プロセスを停止 |
 | `ENOENT`     | Git 実行ファイルが見つからない | Git の PATH を確認、再インストール  |
 
-上記で解決しない場合は [Issues](https://github.com/hashiramaendure/maestro/issues) で検索または新規 Issue を作成してください。
+上記で解決しない場合は [Issues](https://github.com/camoneart/maestro/issues) で検索または新規 Issue を作成してください。
 
 ### 🔍 デバッグモード
 
@@ -281,7 +281,7 @@ DEBUG=mst:* mst review --auto-flow &> maestro-debug.log
 
 ### 🤝 コントリビューションの流れ
 
-1. [**Issue**](https://github.com/hashiramaendure/maestro/issues) でバグ報告・機能提案を送る
+1. [**Issue**](https://github.com/camoneart/maestro/issues) でバグ報告・機能提案を送る
 2. このリポジトリを **Fork** し、`feat/your-topic` などのブランチを作成
 3. 開発後 `pnpm lint && pnpm test` でスタイルとテストを通過させる
 4. **Conventional Commits** 形式でコミット

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Maestro
 
 [![Node.js >=20.0.0](https://img.shields.io/badge/Node.js-%3E%3D20.0.0-45CC11?labelColor=555555&style=flat&logoColor=FFFFFF)](https://nodejs.org/)
-[![npm version](https://img.shields.io/npm/v/@hashiramaendure/maestro?color=007EC5&labelColor=555555&style=flat&logoColor=FFFFFF)](https://www.npmjs.com/package/@hashiramaendure/maestro)
+[![npm version](https://img.shields.io/npm/v/@camoneart/maestro?color=007EC5&labelColor=555555&style=flat&logoColor=FFFFFF)](https://www.npmjs.com/package/@camoneart/maestro)
 [![License MIT](https://img.shields.io/badge/License-MIT-yellow?labelColor=555555&style=flat)](https://opensource.org/licenses/MIT)
 
 ![maestro](public/image/logo/maestro-logo.png)
@@ -54,7 +54,7 @@ Maestro is a CLI that makes Git Worktree management intuitive. When working on m
 ### Homebrew (recommended)
 
 ```bash
-brew install hashiramaendure/tap/maestro
+brew install camoneart/tap/maestro
 ```
 
 * Homebrew installs completion scripts for **zsh / fish / bash** automatically.<br>
@@ -63,7 +63,7 @@ brew install hashiramaendure/tap/maestro
 ### npm
 
 ```bash
-npm install -g @hashiramaendure/maestro
+npm install -g @camoneart/maestro
 ```
 
 ### pnpm
@@ -72,14 +72,14 @@ npm install -g @hashiramaendure/maestro
 # If pnpm is not installed yet
 npm install -g pnpm
 
-pnpm add -g @hashiramaendure/maestro
+pnpm add -g @camoneart/maestro
 ```
 
 ## Quick Start
 
 ```bash
 # 1. Install (Homebrew example)
-brew install hashiramaendure/tap/maestro
+brew install camoneart/tap/maestro
 
 # 2. Move to your Git project
 cd ~/path/to/your-repo
@@ -264,7 +264,7 @@ mst completion fish > ~/.config/fish/completions/mst.fish
 | `EADDRINUSE` | MCP server port in use | `mst mcp stop` to kill previous process |
 | `ENOENT`     | Git binary not found   | Check PATH or reinstall Git             |
 
-If the issue persists, search or open a new ticket in the [Issues](https://github.com/hashiramaendure/maestro/issues).
+If the issue persists, search or open a new ticket in the [Issues](https://github.com/camoneart/maestro/issues).
 
 ### 🔍 Debug Mode
 
@@ -280,7 +280,7 @@ DEBUG=mst:* mst review --auto-flow &> maestro-debug.log
 
 ### 🤝 Contribution Workflow
 
-1. Open an [Issue](https://github.com/hashiramaendure/maestro/issues) for bugs or feature requests.
+1. Open an [Issue](https://github.com/camoneart/maestro/issues) for bugs or feature requests.
 2. Fork the repo and create a branch like `feat/your-topic`.
 3. Run `pnpm lint && pnpm test` and make sure everything passes.
 4. Commit with **Conventional Commits**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ We take the security of maestro seriously. If you believe you have found a secur
 **Please do not report security vulnerabilities through public GitHub issues.**
 
 Instead, please report them via email to:
-- Primary: [Create a security advisory](https://github.com/hashiramaendure/maestro/security/advisories/new) on GitHub
+- Primary: [Create a security advisory](https://github.com/camoneart/maestro/security/advisories/new) on GitHub
 - Alternative: Open an issue with the `security` label (for low-severity issues only)
 
 ### What to Include

--- a/docs/AI_REVIEW.md
+++ b/docs/AI_REVIEW.md
@@ -90,7 +90,7 @@ This project uses Codecov for test coverage reporting. The coverage reports are 
 ## Setup for Repository Maintainers
 
 1. **Visit Codecov**:
-   - Go to [https://app.codecov.io/github/hashiramaendure/maestro](https://app.codecov.io/github/hashiramaendure/maestro)
+   - Go to [https://app.codecov.io/github/camoneart/maestro](https://app.codecov.io/github/camoneart/maestro)
    - Sign in with GitHub account
 
 2. **Get Upload Token**:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hashiramaendure/maestro",
+  "name": "@camoneart/maestro",
   "version": "2.5.0",
   "description": "Git Worktreeを活用した「オーケストラ開発」で、Claude Codeとのパラレル開発を飛躍的に効率化するCLIツール",
   "type": "module",
@@ -33,15 +33,15 @@
     "claude",
     "development-tools"
   ],
-  "author": "hashiramaendure",
+  "author": "camoneart",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hashiramaendure/maestro.git"
+    "url": "git+https://github.com/camoneart/maestro.git"
   },
-  "homepage": "https://github.com/hashiramaendure/maestro#readme",
+  "homepage": "https://github.com/camoneart/maestro#readme",
   "bugs": {
-    "url": "https://github.com/hashiramaendure/maestro/issues"
+    "url": "https://github.com/camoneart/maestro/issues"
   },
   "packageManager": "pnpm@10.13.1",
   "engines": {

--- a/scoop/README.md
+++ b/scoop/README.md
@@ -5,7 +5,7 @@ This directory contains the Scoop manifest for installing maestro on Windows.
 ## Installation
 
 ```powershell
-scoop bucket add hashiramaendure https://github.com/hashiramaendure/scoop-bucket
+scoop bucket add camoneart https://github.com/camoneart/scoop-bucket
 scoop install maestro
 ```
 

--- a/scoop/maestro.json
+++ b/scoop/maestro.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "description": "Git Worktree management tool with Claude Code integration",
-  "homepage": "https://github.com/hashiramaendure/maestro",
+  "homepage": "https://github.com/camoneart/maestro",
   "license": "MIT",
   "architecture": {
     "64bit": {
@@ -44,6 +44,6 @@
     "  mst --help",
     "",
     "For more information, visit:",
-    "  https://github.com/hashiramaendure/maestro"
+    "  https://github.com/camoneart/maestro"
   ]
 }


### PR DESCRIPTION
## Summary
- Changed GitHub username references from `hashiramaendure` to `camoneart` across 52 locations
- Updated package.json repository information and author field
- Updated all documentation links and references
- Updated CI/CD workflow references

## Changes Made
- **Documentation**: README.md, README.ja.md, CONTRIBUTING.md
- **Package Info**: package.json, scoop manifests
- **Security**: SECURITY.md, CODE_OF_CONDUCT.md  
- **CI/CD**: .github/workflows/ci.yml codecov references
- **Legal**: LICENSE copyright holder
- **Release Notes**: CHANGELOG.md historical references

## Test Plan  
- [x] Verified no `hashiramaendure` references remain
- [x] All links point to new `camoneart` repository
- [x] Package information correctly updated
- [x] CI/CD workflows reference correct repository

🤖 Generated with [Claude Code](https://claude.ai/code)