### PR TITLE
fix: update GitHub CLI draft field compatibility

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -25,7 +25,7 @@ interface ItemInfo {
   number: number
   title: string
   author: { login: string }
-  draft?: boolean
+  isDraft?: boolean
   headRefName?: string
 }
 
@@ -279,7 +279,7 @@ async function fetchItems(type: 'pr' | 'issue'): Promise<ItemInfo[]> {
   const spinner = ora(`${type === 'pr' ? 'Pull Request' : 'Issue'}一覧を取得中...`).start()
 
   try {
-    const fields = type === 'pr' ? 'number,title,author,draft' : 'number,title,author'
+    const fields = type === 'pr' ? 'number,title,author,isDraft' : 'number,title,author'
     const result = await execa('gh', [type, 'list', '--json', fields, '--limit', '20'])
     spinner.stop()
     return JSON.parse(result.stdout)
@@ -303,7 +303,7 @@ async function selectItem(items: ItemInfo[], type: 'pr' | 'issue'): Promise<stri
       name: 'selectedNumber',
       message: `${type === 'pr' ? 'Pull Request' : 'Issue'}を選択:`,
       choices: items.map(item => ({
-        name: `#${item.number} ${item.title} ${chalk.gray(`by ${item.author.login}`)}${item.draft ? chalk.yellow(' [draft]') : ''}`,
+        name: `#${item.number} ${item.title} ${chalk.gray(`by ${item.author.login}`)}${item.isDraft ? chalk.yellow(' [draft]') : ''}`,
         value: item.number.toString(),
       })),
       pageSize: 15,

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -30,7 +30,7 @@ interface PullRequest {
   baseRefName: string
   state: string
   url: string
-  draft?: boolean
+  isDraft?: boolean
   reviewers?: GithubUser[]
   assignees?: GithubUser[]
 }
@@ -300,7 +300,7 @@ export const reviewCommand = new Command('review')
           'pr',
           'list',
           '--json',
-          'number,title,author,draft,state',
+          'number,title,author,isDraft,state',
           '--limit',
           '30',
         ])
@@ -320,7 +320,7 @@ export const reviewCommand = new Command('review')
             message: 'レビューするPRを選択:',
             choices: prs.map(pr => ({
               name: `#${pr.number} ${pr.title} ${chalk.gray(`by ${pr.author.login}`)}${
-                pr.draft ? chalk.yellow(' [draft]') : ''
+                pr.isDraft ? chalk.yellow(' [draft]') : ''
               }`,
               value: pr.number.toString(),
             })),


### PR DESCRIPTION
## Summary
- Fix GitHub CLI JSON field compatibility issue in review and github commands
- Update field name from `draft` to `isDraft` to match current GitHub CLI API

## Issue
The `mst review` command was failing with error:
```
Unknown JSON field: "draft"
```

## Changes
- Updated `src/commands/review.ts` to use `isDraft` field
- Updated `src/commands/github.ts` to use `isDraft` field  
- Fixed TypeScript interface definitions

## Test plan
- [x] Build passes successfully
- [ ] Test `mst review` command works without errors
- [ ] Verify draft PR detection still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)