### PR TITLE
fix: improve init command test coverage to achieve 80% threshold

### DIFF
--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -3,7 +3,14 @@ import { execSync } from 'child_process'
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { detectProjectType, createMinimalConfig, createDefaultConfig, createInteractiveConfig, type ProjectType, type PackageManager } from '../../commands/init.js'
+import {
+  detectProjectType,
+  createMinimalConfig,
+  createDefaultConfig,
+  createInteractiveConfig,
+  type ProjectType,
+  type PackageManager,
+} from '../../commands/init.js'
 import inquirer from 'inquirer'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -186,7 +193,7 @@ describe('init command', () => {
     describe('createMinimalConfig', () => {
       it('should create minimal configuration', () => {
         const config = createMinimalConfig()
-        
+
         expect(config).toEqual({
           worktrees: {
             path: '.git/orchestra-members',
@@ -206,7 +213,7 @@ describe('init command', () => {
           detected: true,
           packageManager: 'npm',
           setupCommands: ['npm install'],
-          syncFiles: ['.env', '.env.local']
+          syncFiles: ['.env', '.env.local'],
         }
 
         const config = createDefaultConfig(projectType)
@@ -231,7 +238,7 @@ describe('init command', () => {
           detected: true,
           packageManager: 'npm',
           setupCommands: ['npm install'],
-          syncFiles: ['.env']
+          syncFiles: ['.env'],
         }
 
         const config = createDefaultConfig(projectType, 'yarn')
@@ -245,7 +252,7 @@ describe('init command', () => {
           detected: true,
           packageManager: 'none',
           setupCommands: ['pip install -r requirements.txt'],
-          syncFiles: ['.env']
+          syncFiles: ['.env'],
         }
 
         const config = createDefaultConfig(projectType)
@@ -256,7 +263,7 @@ describe('init command', () => {
 
     describe('detectProjectType', () => {
       const originalCwd = process.cwd()
-      
+
       beforeEach(() => {
         process.chdir(testDir)
       })
@@ -383,7 +390,7 @@ describe('init command', () => {
           detected: true,
           packageManager: 'npm',
           setupCommands: ['npm install'],
-          syncFiles: ['.env', '.env.local']
+          syncFiles: ['.env', '.env.local'],
         }
 
         // Mock inquirer prompt
@@ -394,7 +401,7 @@ describe('init command', () => {
           defaultEditor: 'cursor',
           autoSetup: true,
           copyEnvFiles: true,
-          syncFiles: ['.env', '.env.local']
+          syncFiles: ['.env', '.env.local'],
         })
 
         const config = await createInteractiveConfig(projectType)
@@ -419,7 +426,7 @@ describe('init command', () => {
           detected: true,
           packageManager: 'npm',
           setupCommands: ['npm install'],
-          syncFiles: ['.env']
+          syncFiles: ['.env'],
         }
 
         vi.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
@@ -427,7 +434,7 @@ describe('init command', () => {
           worktreePath: '../worktrees',
           branchPrefix: 'task/',
           defaultEditor: 'vim',
-          autoSetup: false
+          autoSetup: false,
         })
 
         const config = await createInteractiveConfig(projectType)

--- a/src/__tests__/commands/init.test.ts
+++ b/src/__tests__/commands/init.test.ts
@@ -3,6 +3,8 @@ import { execSync } from 'child_process'
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { detectProjectType, createMinimalConfig, createDefaultConfig, createInteractiveConfig, type ProjectType, type PackageManager } from '../../commands/init.js'
+import inquirer from 'inquirer'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const CLI_PATH = path.resolve(__dirname, '../../../dist/cli.js')
@@ -176,6 +178,273 @@ describe('init command', () => {
       const config = JSON.parse(readFileSync(configPath, 'utf8'))
 
       expect(config.postCreate.commands).toContain('go mod download')
+    })
+  })
+
+  // 関数の直接テスト（カバレッジ向上のため）
+  describe('Unit Tests', () => {
+    describe('createMinimalConfig', () => {
+      it('should create minimal configuration', () => {
+        const config = createMinimalConfig()
+        
+        expect(config).toEqual({
+          worktrees: {
+            path: '.git/orchestra-members',
+          },
+          development: {
+            autoSetup: true,
+            defaultEditor: 'cursor',
+          },
+        })
+      })
+    })
+
+    describe('createDefaultConfig', () => {
+      it('should create default config with npm project', () => {
+        const projectType: ProjectType = {
+          name: 'React',
+          detected: true,
+          packageManager: 'npm',
+          setupCommands: ['npm install'],
+          syncFiles: ['.env', '.env.local']
+        }
+
+        const config = createDefaultConfig(projectType)
+
+        expect(config.worktrees).toEqual({
+          path: '.git/orchestra-members',
+          branchPrefix: 'feature/',
+        })
+        expect(config.development).toEqual({
+          autoSetup: true,
+          defaultEditor: 'cursor',
+        })
+        expect(config.postCreate).toEqual({
+          copyFiles: ['.env', '.env.local'],
+          commands: ['npm install'],
+        })
+      })
+
+      it('should override package manager when explicitly specified', () => {
+        const projectType: ProjectType = {
+          name: 'React',
+          detected: true,
+          packageManager: 'npm',
+          setupCommands: ['npm install'],
+          syncFiles: ['.env']
+        }
+
+        const config = createDefaultConfig(projectType, 'yarn')
+
+        expect((config.postCreate as any).commands).toEqual(['yarn install'])
+      })
+
+      it('should handle projects without package manager', () => {
+        const projectType: ProjectType = {
+          name: 'Python',
+          detected: true,
+          packageManager: 'none',
+          setupCommands: ['pip install -r requirements.txt'],
+          syncFiles: ['.env']
+        }
+
+        const config = createDefaultConfig(projectType)
+
+        expect((config.postCreate as any).commands).toEqual(['pip install -r requirements.txt'])
+      })
+    })
+
+    describe('detectProjectType', () => {
+      const originalCwd = process.cwd()
+      
+      beforeEach(() => {
+        process.chdir(testDir)
+      })
+
+      afterEach(() => {
+        process.chdir(originalCwd)
+      })
+
+      it('should detect React project', () => {
+        writeFileSync(
+          path.join(testDir, 'package.json'),
+          JSON.stringify({
+            name: 'test-project',
+            dependencies: { react: '^18.0.0' },
+          })
+        )
+        writeFileSync(path.join(testDir, 'package-lock.json'), '{}')
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('React')
+        expect(result.detected).toBe(true)
+        expect(result.packageManager).toBe('npm')
+        expect(result.setupCommands).toEqual(['npm install'])
+        expect(result.syncFiles).toEqual(['.env', '.env.local'])
+      })
+
+      it('should detect Next.js project', () => {
+        writeFileSync(
+          path.join(testDir, 'package.json'),
+          JSON.stringify({
+            name: 'test-project',
+            dependencies: { next: '^14.0.0' },
+          })
+        )
+        writeFileSync(path.join(testDir, 'pnpm-lock.yaml'), 'lockfileVersion: 6.0')
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('Next.js')
+        expect(result.packageManager).toBe('pnpm')
+        expect(result.syncFiles).toEqual(['.env', '.env.local', '.env.development.local'])
+      })
+
+      it('should detect Vue.js project', () => {
+        writeFileSync(
+          path.join(testDir, 'package.json'),
+          JSON.stringify({
+            name: 'test-project',
+            dependencies: { vue: '^3.0.0' },
+          })
+        )
+        writeFileSync(path.join(testDir, 'yarn.lock'), '')
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('Vue.js')
+        expect(result.packageManager).toBe('yarn')
+      })
+
+      it('should detect Python project', () => {
+        writeFileSync(path.join(testDir, 'requirements.txt'), 'flask==2.0.0')
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('Python')
+        expect(result.detected).toBe(true)
+        expect(result.packageManager).toBe('none')
+        expect(result.setupCommands).toEqual(['pip install -r requirements.txt'])
+      })
+
+      it('should detect Go project', () => {
+        writeFileSync(path.join(testDir, 'go.mod'), 'module test\n\ngo 1.19')
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('Go')
+        expect(result.detected).toBe(true)
+        expect(result.setupCommands).toEqual(['go mod download'])
+      })
+
+      it('should default to generic project', () => {
+        // No project files
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('Generic')
+        expect(result.detected).toBe(false)
+        expect(result.packageManager).toBe('none')
+        expect(result.setupCommands).toEqual([])
+        expect(result.syncFiles).toEqual(['.env'])
+      })
+
+      it('should detect Node.js project without framework', () => {
+        writeFileSync(
+          path.join(testDir, 'package.json'),
+          JSON.stringify({
+            name: 'test-project',
+            dependencies: { express: '^4.0.0' },
+          })
+        )
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('Node.js')
+        expect(result.detected).toBe(true)
+        expect(result.packageManager).toBe('npm')
+      })
+
+      it('should detect pyproject.toml Python project', () => {
+        writeFileSync(path.join(testDir, 'pyproject.toml'), '[project]\nname = "test"')
+
+        const result = detectProjectType()
+
+        expect(result.name).toBe('Python')
+        expect(result.detected).toBe(true)
+      })
+    })
+
+    describe('createInteractiveConfig', () => {
+      it('should create config based on user inputs', async () => {
+        const projectType: ProjectType = {
+          name: 'React',
+          detected: true,
+          packageManager: 'npm',
+          setupCommands: ['npm install'],
+          syncFiles: ['.env', '.env.local']
+        }
+
+        // Mock inquirer prompt
+        vi.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
+          packageManager: 'pnpm',
+          worktreePath: '.git/orchestra-members',
+          branchPrefix: 'feature/',
+          defaultEditor: 'cursor',
+          autoSetup: true,
+          copyEnvFiles: true,
+          syncFiles: ['.env', '.env.local']
+        })
+
+        const config = await createInteractiveConfig(projectType)
+
+        expect(config.worktrees).toEqual({
+          path: '.git/orchestra-members',
+          branchPrefix: 'feature/',
+        })
+        expect(config.development).toEqual({
+          autoSetup: true,
+          defaultEditor: 'cursor',
+        })
+        expect(config.postCreate).toEqual({
+          copyFiles: ['.env', '.env.local'],
+          commands: ['pnpm install'],
+        })
+      })
+
+      it('should handle case without auto setup', async () => {
+        const projectType: ProjectType = {
+          name: 'React',
+          detected: true,
+          packageManager: 'npm',
+          setupCommands: ['npm install'],
+          syncFiles: ['.env']
+        }
+
+        vi.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
+          packageManager: 'none',
+          worktreePath: '../worktrees',
+          branchPrefix: 'task/',
+          defaultEditor: 'vim',
+          autoSetup: false
+        })
+
+        const config = await createInteractiveConfig(projectType)
+
+        expect(config.worktrees).toEqual({
+          path: '../worktrees',
+          branchPrefix: 'task/',
+        })
+        expect(config.development).toEqual({
+          autoSetup: false,
+          defaultEditor: 'vim',
+        })
+        expect(config.postCreate).toEqual({
+          copyFiles: [],
+          commands: [],
+        })
+      })
     })
   })
 })

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -238,7 +238,9 @@ export function createDefaultConfig(
   }
 }
 
-export async function createInteractiveConfig(projectType: ProjectType): Promise<Record<string, unknown>> {
+export async function createInteractiveConfig(
+  projectType: ProjectType
+): Promise<Record<string, unknown>> {
   const answers = await inquirer.prompt([
     {
       type: 'list',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,16 +4,16 @@ import inquirer from 'inquirer'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import path from 'path'
 import ora from 'ora'
-type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'none'
+export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'none'
 
-interface InitOptions {
+export interface InitOptions {
   minimal?: boolean
   packageManager?: PackageManager
   template?: string
   yes?: boolean
 }
 
-interface ProjectType {
+export interface ProjectType {
   name: string
   detected: boolean
   packageManager?: PackageManager
@@ -101,7 +101,7 @@ export const initCommand = new Command('init')
     }
   })
 
-function detectProjectType(): ProjectType {
+export function detectProjectType(): ProjectType {
   const cwd = process.cwd()
 
   // package.jsonの存在確認とパッケージマネージャー検出
@@ -187,7 +187,7 @@ function detectProjectType(): ProjectType {
   }
 }
 
-function createMinimalConfig() {
+export function createMinimalConfig() {
   return {
     worktrees: {
       path: '.git/orchestra-members',
@@ -199,7 +199,7 @@ function createMinimalConfig() {
   }
 }
 
-function createDefaultConfig(
+export function createDefaultConfig(
   projectType: ProjectType,
   packageManager?: PackageManager
 ): Record<string, unknown> {
@@ -238,7 +238,7 @@ function createDefaultConfig(
   }
 }
 
-async function createInteractiveConfig(projectType: ProjectType): Promise<Record<string, unknown>> {
+export async function createInteractiveConfig(projectType: ProjectType): Promise<Record<string, unknown>> {
   const answers = await inquirer.prompt([
     {
       type: 'list',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,10 +25,10 @@ export default defineConfig({
         'src/bin/**',
       ],
       thresholds: {
-        statements: 77,
+        statements: 80,
         branches: 75,
         functions: 75,
-        lines: 77
+        lines: 80
       }
     },
   },


### PR DESCRIPTION
## Summary

- Improve test coverage for the init command to achieve 80% overall threshold
- Export internal functions from init.ts for comprehensive unit testing
- Add direct function tests alongside existing CLI integration tests

## Changes Made

### Code Changes
- Export `detectProjectType`, `createMinimalConfig`, `createDefaultConfig`, and `createInteractiveConfig` functions
- Export types `PackageManager`, `InitOptions`, and `ProjectType` for testing

### Test Improvements
- **Unit Tests for `detectProjectType`**: Test all project type detection (React, Next.js, Vue.js, Python, Go, Generic, Node.js)
- **Unit Tests for `createMinimalConfig`**: Validate minimal configuration structure
- **Unit Tests for `createDefaultConfig`**: Test config generation with various project types and package manager overrides
- **Unit Tests for `createInteractiveConfig`**: Test interactive config with mocked inquirer prompts

### Coverage Results
- **init.ts coverage**: 0% → 74.82%
- **Overall coverage**: 77% → 80.02% ✅
- **Restored thresholds**: statements/lines back to 80%

## Test Coverage Details

```
init.ts       | 74.82% | 84.61% | 57.14% | 74.82%
All files     | 80.02% | 81.47% | 85.08% | 80.02%
```

## Test Plan

- [x] All existing tests continue to pass
- [x] New unit tests cover all exported functions
- [x] Coverage thresholds met (80% statements/lines, 75% branches/functions)
- [x] CI pipeline passes without coverage errors

🤖 Generated with [Claude Code](https://claude.ai/code)