### PR TITLE
fix: resolve Issue #62 - gitignore auto-addition bug

### DIFF
--- a/src/__tests__/utils/gitignore.test.ts
+++ b/src/__tests__/utils/gitignore.test.ts
@@ -100,4 +100,27 @@ describe('gitignore utility', () => {
       expect(result).toBe(false)
     })
   })
+
+  describe('addToGitignore with comment', () => {
+    it('should add entry with comment to .gitignore', async () => {
+      writeFileSync(gitignorePath, 'node_modules/\n', 'utf-8')
+
+      await addToGitignore(testDir, '.maestro-metadata.json', 'maestro metadata')
+
+      const content = readFileSync(gitignorePath, 'utf-8')
+      expect(content).toContain('# maestro metadata')
+      expect(content).toContain('.maestro-metadata.json')
+      expect(content.indexOf('# maestro metadata')).toBeLessThan(content.indexOf('.maestro-metadata.json'))
+    })
+
+    it('should not add comment for existing entry', async () => {
+      writeFileSync(gitignorePath, 'node_modules/\n.maestro-metadata.json\n', 'utf-8')
+
+      await addToGitignore(testDir, '.maestro-metadata.json', 'maestro metadata')
+
+      const content = readFileSync(gitignorePath, 'utf-8')
+      expect(content).not.toContain('# maestro metadata')
+      expect(content.split('.maestro-metadata.json')).toHaveLength(2) // Only one occurrence
+    })
+  })
 })

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -144,10 +144,8 @@ export async function saveWorktreeMetadata(
   try {
     await fs.writeFile(metadataPath, JSON.stringify(metadataContent, null, 2))
 
-    // プロジェクトルートの.gitignoreに.maestro-metadata.jsonを追加
-    const git = new GitWorktreeManager()
-    const projectRoot = await git.getRepositoryRoot()
-    await addToGitignore(projectRoot, '.maestro-metadata.json')
+    // worktreeの.gitignoreに.maestro-metadata.jsonを追加
+    await addToGitignore(worktreePath, '.maestro-metadata.json', 'maestro metadata')
   } catch {
     // メタデータの保存に失敗しても処理は続行
   }

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'fs'
 import path from 'path'
 
-export async function addToGitignore(projectPath: string, entry: string): Promise<void> {
+export async function addToGitignore(projectPath: string, entry: string, comment?: string): Promise<void> {
   const gitignorePath = path.join(projectPath, '.gitignore')
 
   let gitignoreContent = ''
@@ -14,8 +14,15 @@ export async function addToGitignore(projectPath: string, entry: string): Promis
   }
 
   if (!entryExists) {
-    const entryToAdd =
-      gitignoreContent && !gitignoreContent.endsWith('\n') ? `\n${entry}\n` : `${entry}\n`
+    let entryToAdd: string
+    if (comment) {
+      const commentLine = `# ${comment}`
+      entryToAdd = gitignoreContent && !gitignoreContent.endsWith('\n') 
+        ? `\n\n${commentLine}\n${entry}\n` 
+        : `\n${commentLine}\n${entry}\n`
+    } else {
+      entryToAdd = gitignoreContent && !gitignoreContent.endsWith('\n') ? `\n${entry}\n` : `${entry}\n`
+    }
 
     if (existsSync(gitignorePath)) {
       appendFileSync(gitignorePath, entryToAdd, 'utf-8')


### PR DESCRIPTION
## Summary

- Fix gitignore auto-addition targeting wrong directory (main branch instead of worktree)
- Enhance addToGitignore function with comment support for better organization
- Add comprehensive test coverage for new functionality

## Problem

Issue #62 reported that when creating new worktrees with `mst create`, the `.maestro-metadata.json` entry was incorrectly added to the **main branch's `.gitignore`** instead of the **individual worktree's `.gitignore`**.

This caused unintended modifications to the shared main branch, affecting all team members instead of isolating changes to specific worktrees.

## Solution

### 1. Fixed Target Directory
- **Before**: `await addToGitignore(projectRoot, '.maestro-metadata.json')` (main branch)
- **After**: `await addToGitignore(worktreePath, '.maestro-metadata.json', 'maestro metadata')` (worktree-specific)

### 2. Enhanced Functionality
- Added optional `comment` parameter to `addToGitignore` function
- Now adds descriptive comment `# maestro metadata` above the entry
- Maintains backward compatibility with existing usage

### 3. Comprehensive Testing
- Added 2 new test cases for comment functionality
- Total test coverage increased from 10 to 12 test cases
- All tests passing with proper edge case coverage

## Test Plan

- [x] All existing tests pass (12/12)
- [x] New comment functionality works correctly
- [x] Gitignore entries are added to worktree-specific files only
- [x] Main branch `.gitignore` remains unmodified
- [x] Lint and typecheck pass without errors

🤖 Generated with [Claude Code](https://claude.ai/code)