### PR TITLE
fix: Move worktrees outside .git directory (Issue #67)

### DIFF
--- a/src/__tests__/core/git.test.ts
+++ b/src/__tests__/core/git.test.ts
@@ -97,7 +97,7 @@ locked reason`
     it('should create a new worktree', async () => {
       const branchName = 'feature-test'
       const mockRepoRoot = '/test/repo'
-      const expectedPath = path.resolve(mockRepoRoot, '.git/orchestrations/' + branchName)
+      const expectedPath = path.resolve(mockRepoRoot, '..', `maestro-${branchName}`)
 
       // checkBranchNameCollisionをモック（衝突なし）
       vi.spyOn(gitManager, 'checkBranchNameCollision').mockResolvedValueOnce()
@@ -117,7 +117,7 @@ locked reason`
         'add',
         '-b',
         branchName,
-        path.join(mockRepoRoot, '.git/orchestrations/feature-test'),
+        path.join(mockRepoRoot, '..', 'maestro-feature-test'),
         'main',
       ])
     })
@@ -126,7 +126,7 @@ locked reason`
       const branchName = 'feature-test'
       const baseBranch = 'develop'
       const mockRepoRoot = '/test/repo'
-      const expectedPath = path.resolve(mockRepoRoot, '.git/orchestrations/' + branchName)
+      const expectedPath = path.resolve(mockRepoRoot, '..', `maestro-${branchName}`)
 
       // checkBranchNameCollisionをモック（衝突なし）
       vi.spyOn(gitManager, 'checkBranchNameCollision').mockResolvedValueOnce()
@@ -145,7 +145,7 @@ locked reason`
         'add',
         '-b',
         branchName,
-        path.join(mockRepoRoot, '.git/orchestrations/feature-test'),
+        path.join(mockRepoRoot, '..', 'maestro-feature-test'),
         baseBranch,
       ])
     })
@@ -186,18 +186,23 @@ locked reason`
   describe('attachWorktree', () => {
     it('should attach to an existing branch', async () => {
       const branchName = 'existing-feature'
-      const expectedPath = path.resolve('.git/orchestrations/existing-feature')
-
-      // git.raw()をモック
-      ;(gitManager as any).git.raw = vi.fn().mockResolvedValue('')
+      const mockRepoRoot = '/test/repo'
+      
+      // getRepositoryRoot()をモック
+      ;(gitManager as any).git.raw = vi
+        .fn()
+        .mockResolvedValueOnce(mockRepoRoot + '\n') // getRepositoryRoot()
+        .mockResolvedValueOnce('') // worktree add
+      
+      const expectedPath = path.resolve(mockRepoRoot, '..', 'maestro-existing-feature')
 
       const result = await gitManager.attachWorktree(branchName)
 
       expect(result).toBe(expectedPath)
-      expect((gitManager as any).git.raw).toHaveBeenCalledWith([
+      expect((gitManager as any).git.raw).toHaveBeenNthCalledWith(2, [
         'worktree',
         'add',
-        '.git/orchestrations/existing-feature',
+        path.join(mockRepoRoot, '..', 'maestro-existing-feature'),
         branchName,
       ])
     })

--- a/src/__tests__/core/git.test.ts
+++ b/src/__tests__/core/git.test.ts
@@ -187,13 +187,13 @@ locked reason`
     it('should attach to an existing branch', async () => {
       const branchName = 'existing-feature'
       const mockRepoRoot = '/test/repo'
-      
+
       // getRepositoryRoot()をモック
       ;(gitManager as any).git.raw = vi
         .fn()
         .mockResolvedValueOnce(mockRepoRoot + '\n') // getRepositoryRoot()
         .mockResolvedValueOnce('') // worktree add
-      
+
       const expectedPath = path.resolve(mockRepoRoot, '..', 'maestro-existing-feature')
 
       const result = await gitManager.attachWorktree(branchName)

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -104,7 +104,7 @@ export type Config = z.infer<typeof ConfigSchema>
 // デフォルト設定
 const DEFAULT_CONFIG: Config = {
   worktrees: {
-    path: '.git/orchestrations',
+    path: '../maestro-{branch}',
   },
   development: {
     autoSetup: true,
@@ -202,7 +202,7 @@ export class ConfigManager {
     const targetPath = configPath || path.join(process.cwd(), '.maestro.json')
     const exampleConfig: Partial<Config> = {
       worktrees: {
-        path: '.git/orchestrations',
+        path: '../maestro-{branch}',
         branchPrefix: 'feature/',
       },
       development: {

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -15,7 +15,7 @@ export class GitWorktreeManager {
 
     // リポジトリルートを取得して絶対パスを生成
     const repoRoot = await this.getRepositoryRoot()
-    const worktreePath = path.join(repoRoot, '.git', 'orchestrations', branchName)
+    const worktreePath = path.join(repoRoot, '..', `maestro-${branchName}`)
 
     // ベースブランチが指定されていない場合は現在のブランチを使用
     if (!baseBranch) {
@@ -34,7 +34,7 @@ export class GitWorktreeManager {
     const repoRoot = await this.getRepositoryRoot()
     // ワークツリーのパスを生成（ブランチ名からスラッシュを置換）
     const safeBranchName = existingBranch.replace(/\//g, '-')
-    const worktreePath = path.join(repoRoot, '.git', 'orchestrations', safeBranchName)
+    const worktreePath = path.join(repoRoot, '..', `maestro-${safeBranchName}`)
 
     // 既存のブランチでワークツリーを作成
     await this.git.raw(['worktree', 'add', worktreePath, existingBranch])


### PR DESCRIPTION
## Summary

- Move worktree creation from `.git/orchestrations/` to `../maestro-{branch}` to follow Git best practices
- Each worktree is now created as individual directory at same level as main repository
- Update default configuration and tests to support new path structure

## Changes Made

### Core Logic Changes
- **src/core/git.ts**: Updated `createWorktree` and `attachWorktree` methods to use `../maestro-{branch}` path pattern
- **src/core/config.ts**: Changed default worktree path from `.git/orchestrations` to `../maestro-{branch}`

### Test Updates
- **src/__tests__/core/git.test.ts**: Updated test expectations to match new path structure

## Directory Structure

**Before:**
```
/maestro/
└── .git/
    └── orchestrations/    # ❌ Worktrees inside .git
        └── feature-test/
```

**After:**
```
/projects/
├── maestro/              # Main repository
├── maestro-feature1/     # Worktree (individual directory)
└── maestro-feature2/     # Worktree (individual directory)
```

## Test Results

- ✅ All 1080 tests pass
- ✅ TypeScript compilation successful
- ✅ ESLint warnings only (existing code complexity)

## Breaking Changes

⚠️ **Existing worktrees in `.git/orchestrations/` will not be recognized by the new version.** Users will need to:
1. Manually migrate existing worktrees to new location, or
2. Delete and recreate worktrees using new version

## Resolves

Closes #67

🤖 Generated with [Claude Code](https://claude.ai/code)