### PR TITLE
fix: add .maestro-metadata.json to .gitignore (Issue #66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ temp/
 worktrees/
 .maestro-config.json
 .maestro/
+.maestro-metadata.json
 
 # Claude Code
 .claude/export-conversations/


### PR DESCRIPTION
## Summary
- ルートディレクトリの`.maestro-metadata.json`ファイルが未追跡状態になっていた問題を修正
- `.gitignore`ファイルに`.maestro-metadata.json`を追加してworktreeメタデータファイルを適切に無視

## Test plan
- [x] `.maestro-metadata.json`ファイルがgit statusで表示されないことを確認
- [x] `pnpm format`でコードフォーマットが適用されることを確認  
- [x] `pnpm lint && pnpm typecheck`が成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)