### PR TITLE
Fix: Add worktree filtering options to sync command (Issue #73)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -244,29 +244,46 @@ mst delete --fzf
 
 ### 🔸 sync
 
-Sync files between orchestra members.
+Sync changes from main branch to orchestra members.
 
 ```bash
-mst sync [options]
+mst sync [branch-name] [options]
 ```
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--files` | | Copy files to target worktrees |
+| `--all` | `-a` | Sync all orchestra members |
+| `--main <branch>` | `-m` | Specify main branch (default: main or master) |
+| `--fzf` | | Select with fzf |
+| `--rebase` | | Use rebase instead of merge |
 | `--dry-run` | | Preview only, don't sync |
-| `--auto` | | Auto sync mode |
+| `--push` | | Push after merge/rebase |
+| `--filter <keyword>` | | Filter worktrees by branch name or path |
+| `--pattern <pattern>` | | Filter worktrees by wildcard pattern |
+| `--files` | `-f` | Copy environment/config files |
+| `--interactive` | `-i` | Interactive file selection |
+| `--preset <name>` | `-p` | Use sync preset (env, config, all) |
 | `--concurrency <number>` | `-c` | Number of parallel executions (default: 5) |
 
 #### Examples
 ```bash
-# Basic sync
-mst sync
+# Sync specific branch
+mst sync feature/auth
 
-# Copy files to target worktrees
-mst sync --files
+# Sync all branches
+mst sync --all
 
-# Dry run mode
-mst sync --dry-run
+# Filter by keyword
+mst sync --filter feature --all
+
+# Filter by pattern
+mst sync --pattern "feature/*" --all
+
+# Sync with rebase
+mst sync --rebase --all
+
+# Copy environment files
+mst sync --files --all
 ```
 
 ### 🔸 shell


### PR DESCRIPTION
## Summary

- ✅ Add `--filter` option for keyword-based worktree filtering
- ✅ Add `--pattern` option for wildcard pattern matching (e.g., `feature/*`)  
- ✅ Fix "main worktree not found" error when using sync filters
- ✅ Maintain backward compatibility with existing file sync options
- ✅ Add comprehensive test coverage (29 tests passing)
- ✅ Update documentation

## Problem

Issue #73 reported that using filter options with `mst sync` resulted in "main worktree not found" errors:

- `mst sync -f feature/` → Error
- `mst sync -i feature/test` → Error  
- `mst sync -p "feature.*"` → Error

## Root Cause

The existing `-f`, `-i`, `-p` options were designed for **file synchronization**, not **worktree filtering**. Users expected these options to filter worktrees, but they were actually triggering file sync functionality which caused the error.

## Solution

Added dedicated worktree filtering options:

- **`--filter <keyword>`**: Filter by keyword in branch name or path (case-insensitive)
- **`--pattern <pattern>`**: Filter by wildcard pattern (supports `*` wildcard)
- Both options can be combined with AND logic
- Compatible with existing selection methods (fzf, interactive)

## Usage Examples

```bash
# Filter by keyword 
mst sync --filter feature --all

# Filter by wildcard pattern
mst sync --pattern "feature/*" --all

# Combine filters
mst sync --filter api --pattern "feature/*" --all

# Use with other options
mst sync --filter hotfix --rebase --push --all
```

## Test Plan

- [x] All existing tests pass (29/29)
- [x] New filtering functionality tests added
- [x] Backward compatibility verified  
- [x] Lint and typecheck pass
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)