### PR TITLE
fix: resolve circular reference detection in graph command (Issue #75)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -609,7 +609,7 @@ mst attach --fetch --setup
 
 ### 🔸 graph
 
-Display orchestra member relationships.
+Display orchestra member relationships with automatic circular dependency detection.
 
 ```bash
 mst graph [options]
@@ -623,6 +623,12 @@ mst graph [options]
 | `--show-dates` | | Show last update dates |
 | `--depth <number>` | `-d` | Display depth (default: 3) |
 
+#### Features
+- **Circular Reference Detection**: Automatically detects and resolves circular dependencies between branches
+- **Branch Relationship Analysis**: Shows parent-child relationships and commit divergence
+- **Multiple Output Formats**: Supports Mermaid diagrams and Graphviz DOT format
+- **Health Assessment**: Identifies outdated branches and potential issues
+
 #### Examples
 ```bash
 # Display graph (default: mermaid format)
@@ -630,6 +636,11 @@ mst graph
 
 # Output as DOT format
 mst graph --format dot --output graph.dot
+
+# When circular dependencies are detected, warnings are automatically shown:
+# ⚠️  循環参照が検出されました:
+#   - feature-a → feature-b → feature-c → feature-a
+# 循環参照のあるブランチは main から派生するよう調整されました
 ```
 
 ### 🔸 history

--- a/docs/commands/graph.md
+++ b/docs/commands/graph.md
@@ -90,6 +90,7 @@ The graph command analyzes several aspects of branch relationships:
 - **Commit Analysis**: Shows divergence from parent branches  
 - **Age calculation**: Determines days since last update
 - **Health Assessment**: Identifies branches with no activity for 30+ days
+- **Circular Reference Detection**: Automatically detects and warns about circular dependencies between branches
 
 ## Use Cases
 
@@ -133,6 +134,15 @@ mst graph --show-dates
    # Use depth limiting
    mst graph --depth 2
    ```
+
+3. **Circular reference warnings**
+   ```bash
+   # When circular dependencies are detected:
+   ⚠️  循環参照が検出されました:
+     - feature-a → feature-b → feature-c → feature-a
+   循環参照のあるブランチは main から派生するよう調整されました
+   ```
+   This indicates that some branches have circular dependencies, which have been automatically resolved by connecting them to the main branch instead.
 
 ## Related Commands
 


### PR DESCRIPTION
## Summary
- Implemented automatic circular reference detection in the `graph` command
- Added DFS-based cycle detection algorithm to identify circular dependencies between branches
- Enhanced branch relationship analysis with visitedBranches tracking
- Display user-friendly warning messages when circular references are detected

## Changes Made
### Core Implementation
- **Added `detectCycles()` function**: Uses depth-first search (DFS) algorithm to detect circular dependencies
- **Enhanced `findBetterParent()` function**: Added visitedBranches parameter to prevent infinite loops
- **Updated `analyzeBranchRelations()`**: Integrated cycle detection and warning display

### Test Coverage
- Added comprehensive test cases for circular reference scenarios
- Mock complex dependency chains (feature-a → feature-b → feature-c → feature-a)
- Verify warning messages are properly displayed
- Ensure no false positives when no cycles exist

### Documentation Updates
- Updated `docs/COMMANDS.md` with circular reference detection feature
- Enhanced `docs/commands/graph.md` with detailed explanation and troubleshooting
- Added example warning messages and their meanings

## Technical Details
The circular reference detection works by:
1. Using DFS traversal to explore branch dependency chains
2. Maintaining a recursion stack to detect back edges (cycles)
3. When cycles are found, automatically resolving them by connecting branches to main
4. Displaying clear warnings to users about detected circular dependencies

## Example Output
When circular dependencies are detected:
```
⚠️  循環参照が検出されました:
  - feature-a → feature-b → feature-c → feature-a
循環参照のあるブランチは main から派生するよう調整されました
```

## Test Plan
- [x] All existing tests pass (889 passed)
- [x] New circular reference detection tests added and passing
- [x] Lint and typecheck pass without errors
- [x] Code formatting applied with prettier

## Fixes
Fixes #75

🤖 Generated with [Claude Code](https://claude.ai/code)