### PR TITLE
fix: remove caret from @types/node version for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@changesets/cli": "2.29.5",
     "@eslint/js": "9.31.0",
     "@types/inquirer": "9.0.8",
-    "@types/node": "^24.1.0",
+    "@types/node": "24.1.0",
     "@typescript-eslint/eslint-plugin": "8.38.0",
     "@typescript-eslint/parser": "8.38.0",
     "@vitest/coverage-v8": "3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         specifier: 9.0.8
         version: 9.0.8
       '@types/node':
-        specifier: ^24.1.0
+        specifier: 24.1.0
         version: 24.1.0
       '@typescript-eslint/eslint-plugin':
         specifier: 8.38.0


### PR DESCRIPTION
## Summary
- Fix `@types/node` version from `^24.1.0` to `24.1.0` for consistency with other dependencies

## Issue
- All other packages in `devDependencies` use fixed versions (without `^`)
- `@types/node` was the only exception using `^24.1.0`

## Changes
- Changed `"@types/node": "^24.1.0"` to `"@types/node": "24.1.0"`
- No functional impact (affects development environment only)

## Test Plan
- [x] Small change, affects TypeScript types only
- [x] No behavioral changes to end users
- [x] Consistent with project's dependency versioning strategy

## Related
- Follow-up to PR #85 (dependency updates)
- Addresses version consistency feedback

🤖 Generated with [Claude Code](https://claude.ai/code)  