### PR TITLE
fix: resolve infinite spinner loading on existing branch error (#95)

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -464,10 +464,16 @@ async function createWorktreeFromGithub(
 
   spinner.start('演奏者を招集中...')
 
-  const worktreePath =
-    type === 'pr'
-      ? await createWorktreeForPR(number, branchName, gitManager)
-      : await gitManager.createWorktree(branchName)
+  let worktreePath: string
+  try {
+    worktreePath =
+      type === 'pr'
+        ? await createWorktreeForPR(number, branchName, gitManager)
+        : await gitManager.createWorktree(branchName)
+  } catch (error) {
+    spinner.fail('演奏者の招集に失敗しました')
+    throw error
+  }
 
   spinner.succeed(
     `演奏者 '${chalk.cyan(branchName)}' を招集しました！\n` +


### PR DESCRIPTION
## Summary

- Fixes infinite spinner loading when attempting to create worktree from GitHub issue with existing branch
- Improves error handling in `createWorktreeFromGithub` function to properly stop spinner on errors
- Adds comprehensive test coverage for branch collision error scenarios

## Problem

Issue #95 reported that when running `mst github issue <number>` with an existing branch, the error message displays correctly but the spinner continues loading infinitely, requiring manual interruption.

**Before:**
```
✔ Issue #90: test
✔ ブランチ 'issue-90' で演奏者を招集しますか？ Yes
✖ エラーが発生しました
ブランチ 'issue-90' は既に存在します
⠼ 演奏者を招集中...   ← Infinite loading
```

**After:**
```
✔ Issue #90: test
✔ ブランチ 'issue-90' で演奏者を招集しますか？ Yes
✖ 演奏者の招集に失敗しました
エラーが発生しました
ブランチ 'issue-90' は既に存在します
```

## Changes

### Code Changes

1. **Enhanced Error Handling** (`src/commands/github.ts:465-476`)
   - Wrapped worktree creation in try-catch block
   - Added `spinner.fail('演奏者の招集に失敗しました')` before re-throwing error
   - Fixed variable scope issue by declaring `worktreePath` outside try block

2. **Test Coverage** (`src/__tests__/commands/github-error-paths.test.ts:502-565`)
   - Added new test case: "should handle branch collision error and stop spinner properly"
   - Verifies `spinner.fail()` is called on branch collision errors
   - Prevents regression of infinite spinner issue

### Implementation Log

- Created detailed implementation log in `_docs/templates/2025-07-25_issue-95-spinner-fix.md`
- Documents problem analysis, solution approach, and verification results

## Test Plan

- [x] All existing tests pass (946 tests successful)
- [x] New test case verifies spinner.fail() is called on error
- [x] Manual testing confirms spinner stops properly on branch collision
- [x] Code formatting and linting checks pass
- [x] TypeScript compilation successful

## Impact

- **User Experience**: Eliminates need for manual process interruption
- **Error Handling**: Improves consistency across GitHub integration commands
- **Maintainability**: Adds test coverage for edge case scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)