### PR TITLE
docs: Add mst init command examples to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -82,6 +82,10 @@ brew install camoneart/tap/maestro
 # 2. Git プロジェクトに移動
 cd ~/path/to/your-repo
 
+# 2.5. プロジェクトで maestro を初期化（新機能！）
+mst init                                      # 対話的セットアップ
+# または: mst init --yes                      # デフォルト設定で素早くセットアップ
+
 # 3. 新しい worktree (演奏者) を作成
 mst create feature/awesome-feature            # まず作成だけ
 
@@ -120,6 +124,7 @@ mst create feature/awesome-feature --tmux --claude
 
 | コマンド    | 説明                       | ショート例                     |
 | ----------- | -------------------------- | ------------------------------ |
+| `init`      | プロジェクト設定を初期化    | `mst init --yes`               |
 | `create`    | 新しい worktree を作成     | `mst create feature/login`     |
 | `list`      | worktree を一覧表示        | `mst list`                     |
 | `delete`    | worktree とローカルブランチを削除 | `mst delete feature/old --fzf` |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ brew install camoneart/tap/maestro
 # 2. Move to your Git project
 cd ~/path/to/your-repo
 
+# 2.5. Initialize maestro for your project (NEW!)
+mst init                                      # Interactive setup
+# or: mst init --yes                          # Quick setup with defaults
+
 # 3. Create a performer (worktree)
 mst create feature/awesome-feature            # create only
 
@@ -122,6 +126,7 @@ See the full [Command Reference](./docs/COMMANDS.md).
 
 | Command     | Description                  | Example                        |
 | ----------- | ---------------------------- | ------------------------------ |
+| `init`      | Initialize project config    | `mst init --yes`               |
 | `create`    | Create a new worktree        | `mst create feature/login`     |
 | `list`      | List worktrees               | `mst list`                     |
 | `delete`    | Delete worktree & local branch | `mst delete feature/old --fzf` |


### PR DESCRIPTION
## Summary
- Added `mst init` command examples to Quick Start sections in both README files
- Added `init` command entry to Main Commands tables
- Maintained consistency between English and Japanese documentation

## Changes Made
1. **Quick Start Section Enhancement**
   - Added step 2.5 showing `mst init` usage with both interactive and quick setup examples
   - Added "(NEW\!)" / "（新機能！）" markers to highlight the new addition

2. **Main Commands Table Update**  
   - Added `init` command as the first entry in the commands table
   - Consistent with the format requested in issue #100

## Test plan
- [x] Verified markdown formatting is correct
- [x] Confirmed consistency between English and Japanese versions
- [x] Ran `pnpm format` to ensure code formatting compliance

Fixes #100

🤖 Generated with [Claude Code](https://claude.ai/code)