### PR TITLE
refactor: Simplify --claude option to focus only on CLAUDE.md file management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
   **Breaking Change**: The `mst claude` command and its subcommands (`start`, `stop`, `list`) are no longer available.
 
-  **Migration**: Use the `claude` command directly in your worktrees. The `--claude` option for `mst create` remains available for CLAUDE.md generation.
+  **Migration**: Use the `claude` command directly in your worktrees. The `--claude-md` option for `mst create` remains available for CLAUDE.md generation.
 
 ## 2.7.4
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -93,20 +93,20 @@ mst create feature/awesome-feature            # まず作成だけ
 mst shell feature/awesome-feature             # シェルへ入室
 
 # ── ワンライナー (tmux + Claude) ──
-# 作成と同時に tmux セッションを作成して自動的にアタッチ & Claude Code を起動
-mst create feature/awesome-feature --tmux --claude
+# 作成と同時に tmux セッションを作成して自動的にアタッチ & Claude Code ワークスペースファイルを設定
+mst create feature/awesome-feature --tmux --claude-md
 ```
 
 #### ポイント
 
 - `mst shell <ブランチ名>` でいつでも演奏者に入れます（省略すると fzf で選択）。
-- `--tmux` を付けると専用 tmux セッションを作成して自動的にアタッチし、`--claude` を併用すると Claude Code も自動起動します。
+- `--tmux` を付けると専用 tmux セッションを作成して自動的にアタッチし、`--claude-md` を併用すると Claude Code ワークスペースファイルを設定します。
 
 ### 基本的な使用例
 
 | 目的                                    | コマンド例                                                                   |
 | --------------------------------------- | ---------------------------------------------------------------------------- |
-| **並列開発** 新機能とバグ修正を同時進行 | `mst create feature/auth --tmux --claude`<br>`mst create bugfix/login-issue` |
+| **並列開発** 新機能とバグ修正を同時進行 | `mst create feature/auth --tmux --claude-md`<br>`mst create bugfix/login-issue` |
 | **状態確認** 演奏者一覧を表示           | `mst list`                                                                   |
 | **高速切替** tmux セッションへ          | `mst tmux`                                                                   |
 | **GitHub Issue から作成**               | `mst create 123`                                                             |
@@ -141,7 +141,7 @@ mst create feature/awesome-feature --tmux --claude
 
 ```bash
 # 代表的な操作
-mst create feature/my-ui --tmux --claude   # 作成 + AI + tmux
+mst create feature/my-ui --tmux --claude-md   # 作成 + AI + tmux
 mst list                                   # 一覧
 mst tmux                                   # fzf で切替
 mst push --pr                              # push with PR
@@ -177,7 +177,7 @@ Maestro は **リポジトリ直下の `.maestro.json`** を読み取り、動�
 |             | `syncFiles`    | 共有したいファイルの配列                | `[".env", ".env.local"]`            |
 | hooks       | `afterCreate`  | 作成後に実行する任意コマンド            | `npm install`                       |
 |             | `beforeDelete` | 削除前フック                            | `echo "Deleting $ORCHESTRA_MEMBER"` |
-| claude      | `autoStart`    | worktree 入室時に Claude Code を起動    | `true`                              |
+| claude      | `markdownMode` | CLAUDE.md ファイル管理モード            | `shared`                            |
 
 #### 完全なサンプル
 
@@ -197,9 +197,7 @@ Maestro は **リポジトリ直下の `.maestro.json`** を読み取り、動�
     "beforeDelete": "echo \"演奏者を削除します: $ORCHESTRA_MEMBER\""
   },
   "claude": {
-    "autoStart": true,
-    "markdownMode": "shared",
-    "initialCommands": ["/model sonnet-3.5"]
+    "markdownMode": "shared"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -95,20 +95,20 @@ mst create feature/awesome-feature            # create only
 mst shell feature/awesome-feature             # open a shell inside
 
 # ── one-liner (tmux + Claude) ──
-# Create the worktree and automatically attach to a tmux session with Claude Code running
-mst create feature/awesome-feature --tmux --claude
+# Create the worktree, automatically attach to a tmux session, and set up Claude Code workspace
+mst create feature/awesome-feature --tmux --claude-md
 ```
 
 #### Tips
 
 - `mst shell <branch>` lets you enter any performer after creation (fzf prompt when omitted).
-- `--tmux` creates a dedicated tmux session and automatically attaches to it; combine with `--claude` to auto-start Claude Code.
+- `--tmux` creates a dedicated tmux session and automatically attaches to it; combine with `--claude-md` to set up Claude Code workspace files.
 
 ### Basic Usage Examples
 
 | Goal                              | Command Example                                                              |
 | --------------------------------- | ---------------------------------------------------------------------------- |
-| **Parallel dev** Feature + bugfix | `mst create feature/auth --tmux --claude`<br>`mst create bugfix/login-issue` |
+| **Parallel dev** Feature + bugfix | `mst create feature/auth --tmux --claude-md`<br>`mst create bugfix/login-issue` |
 | **List performers**               | `mst list`                                                                   |
 | **Fast switch** via tmux          | `mst tmux`                                                                   |
 | **Create from GitHub Issue**      | `mst create 123`                                                             |
@@ -142,7 +142,7 @@ All sub-commands and options are documented in the [Command Reference](./docs/CO
 #### One-line Cheat Sheet
 
 ```bash
-mst create feature/my-ui --tmux --claude   # create + AI + tmux
+mst create feature/my-ui --tmux --claude-md   # create + AI + tmux
 mst list                                   # list performers
 mst tmux                                   # switch via fzf
 mst push --pr                              # push with PR
@@ -177,7 +177,7 @@ Key settings are summarised below; a full example follows.
 |             | `syncFiles`    | Files to sync across worktrees        | `[".env", ".env.local"]`            |
 | hooks       | `afterCreate`  | Command after creation                | `npm install`                       |
 |             | `beforeDelete` | Command before deletion               | `echo "Deleting $ORCHESTRA_MEMBER"` |
-| claude      | `autoStart`    | Start Claude Code on enter            | `true`                              |
+| claude      | `markdownMode` | CLAUDE.md file management mode       | `shared`                            |
 
 #### Full Example
 
@@ -197,9 +197,7 @@ Key settings are summarised below; a full example follows.
     "beforeDelete": "echo \"Deleting performer: $ORCHESTRA_MEMBER\""
   },
   "claude": {
-    "autoStart": true,
-    "markdownMode": "shared",
-    "initialCommands": ["/model sonnet-3.5"]
+    "markdownMode": "shared"
   }
 }
 ```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -97,7 +97,7 @@ mst create <branch-name> [options]
 | `--tmux` | Create tmux session and auto-attach |
 | `--tmux-h` | Create in horizontal tmux pane split |
 | `--tmux-v` | Create in vertical tmux pane split |
-| `--claude` | Create CLAUDE.md for Claude Code |
+| `--claude-md` | Create CLAUDE.md for Claude Code |
 | `--copy-file <file>` | Copy files from current worktree |
 | `--yes`, `-y` | Skip confirmations |
 
@@ -107,14 +107,14 @@ mst create <branch-name> [options]
 mst create feature/awesome-feature
 
 # Full setup
-mst create feature/full-setup --tmux --claude --open --setup
+mst create feature/full-setup --tmux --claude-md --open --setup
 
 # Create from GitHub Issue
 mst create 123  # Auto-generates branch name from Issue #123
 
 # Create with tmux pane split
-mst create feature/new --tmux-h --claude  # Horizontal split with Claude
-mst create issue-456 --tmux-v --setup     # Vertical split with setup
+mst create feature/new --tmux-h --claude-md  # Horizontal split with Claude
+mst create issue-456 --tmux-v --setup        # Vertical split with setup
 
 # Copy environment files to new worktree
 mst create feature/api --copy-file .env --copy-file .env.local

--- a/docs/DRAFT_PR.md
+++ b/docs/DRAFT_PR.md
@@ -46,7 +46,7 @@ You can customize the PR template by modifying the code in `src/commands/create.
 
 ## Tips
 
-- Use with `--tmux --claude` for immediate development start
+- Use with `--tmux --claude-md` for immediate development start
 - The PR URL is displayed after creation
 - You can convert from Draft to Ready later via GitHub UI
 - Works seamlessly with Issue-based branch creation

--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -28,8 +28,8 @@ mst create issue-123     # Created as issue-123
 # Create with tmux session (auto-attaches to the session)
 mst create feature/new-feature --tmux
 
-# Create with tmux session and auto-start Claude Code
-mst create feature/new-feature --tmux --claude
+# Create with tmux session and set up Claude workspace
+mst create feature/new-feature --tmux --claude-md
 
 # Create with tmux pane split options (when already in tmux)
 mst create feature/new-feature --tmux-h  # Horizontal split
@@ -39,7 +39,7 @@ mst create feature/new-feature --tmux-v  # Vertical split
 mst create feature/new-feature --base develop
 
 # Combine all options
-mst create feature/new-feature --base main --open --setup --tmux --claude
+mst create feature/new-feature --base main --open --setup --tmux --claude-md
 ```
 
 ## Options
@@ -52,7 +52,7 @@ mst create feature/new-feature --base main --open --setup --tmux --claude
 | `--tmux`             | `-t`  | Create tmux session and auto-attach                          | `false` |
 | `--tmux-h`           |       | Split tmux pane horizontally (when in tmux)                  | `false` |
 | `--tmux-v`           |       | Split tmux pane vertically (when in tmux)                    | `false` |
-| `--claude`           | `-c`  | Auto-start Claude Code                                        | `false` |
+| `--claude-md`        | `-c`  | Create CLAUDE.md file for Claude Code workspace              | `false` |
 | `--copy-file <file>` |       | Copy files from current worktree (including gitignored files) | none    |
 | `--shell`            |       | Enter shell after creation                                    | `false` |
 | `--exec <command>`   |       | Execute command after creation                                | none    |
@@ -110,18 +110,18 @@ These options create a new pane in your current tmux window and immediately swit
 
 ## Claude Code Integration
 
-Using the `--claude` option automatically starts Claude Code after orchestra member creation:
+Using the `--claude-md` option creates CLAUDE.md workspace files for Claude Code integration:
 
 ```bash
-mst create feature/ai-feature --tmux --claude
+mst create feature/ai-feature --tmux --claude-md
 ```
 
 Executed processes:
 
 1. Worktree creation
 2. tmux session/window creation (with auto-attach if using `--tmux`)
-3. Claude Code startup
-4. Initial command execution (if specified in configuration)
+3. CLAUDE.md file creation for workspace setup
+4. Environment setup (if specified in configuration)
 
 ## Copying Files Feature
 
@@ -190,7 +190,7 @@ The `afterCreate` hook supports both string and array formats:
 
 ```bash
 # Convenient to alias commonly used combinations
-alias mstf='mst create --tmux --claude --setup'
+alias mstf='mst create --tmux --claude-md --setup'
 
 # Usage example
 mstf feature/new-feature
@@ -203,7 +203,7 @@ mstf feature/new-feature
 gh issue list
 
 # Create orchestra member by issue number
-mst create 123 --tmux --claude
+mst create 123 --tmux --claude-md
 
 # Start development
 # Issue information is automatically saved as metadata

--- a/src/__tests__/commands/create-edge-cases.test.ts
+++ b/src/__tests__/commands/create-edge-cases.test.ts
@@ -113,7 +113,6 @@ describe('create command - edge cases', () => {
       ])
     })
 
-
     it('should handle tmux session creation failure', async () => {
       vi.mocked(execa).mockImplementation(async (cmd, args) => {
         if (cmd === 'tmux' && args?.[0] === 'has-session') {
@@ -128,9 +127,7 @@ describe('create command - edge cases', () => {
       const config = { claude: { autoStart: false } }
 
       // Should not throw error
-      await expect(
-        createTmuxSession('feature/test', '/path/to/worktree')
-      ).resolves.not.toThrow()
+      await expect(createTmuxSession('feature/test', '/path/to/worktree')).resolves.not.toThrow()
     })
 
     it('should sanitize session name', async () => {

--- a/src/__tests__/commands/create-edge-cases.test.ts
+++ b/src/__tests__/commands/create-edge-cases.test.ts
@@ -70,7 +70,7 @@ describe('create command - edge cases', () => {
         },
       }
 
-      await createTmuxSession('feature/test', '/path/to/worktree', config)
+      await createTmuxSession('feature/test', '/path/to/worktree')
 
       expect(execa).toHaveBeenCalledWith('tmux', ['has-session', '-t', 'feature-test'])
       expect(execa).toHaveBeenCalledWith('tmux', [
@@ -99,7 +99,7 @@ describe('create command - edge cases', () => {
 
       const config = { claude: { autoStart: false } }
 
-      await createTmuxSession('feature/test', '/path/to/worktree', config)
+      await createTmuxSession('feature/test', '/path/to/worktree')
 
       expect(execa).toHaveBeenCalledWith('tmux', ['has-session', '-t', 'feature-test'])
       // Should not create new session
@@ -113,45 +113,6 @@ describe('create command - edge cases', () => {
       ])
     })
 
-    it('should start Claude Code with initial commands', async () => {
-      vi.mocked(execa).mockImplementation(async (cmd, args) => {
-        if (cmd === 'tmux' && args?.[0] === 'has-session') {
-          throw new Error('session not found')
-        }
-        return { stdout: 'success' }
-      })
-
-      const config = {
-        claude: {
-          autoStart: true,
-          initialCommands: ['echo "hello"', 'pwd'],
-        },
-      }
-
-      await createTmuxSession('feature/test', '/path/to/worktree', config)
-
-      expect(execa).toHaveBeenCalledWith('tmux', [
-        'send-keys',
-        '-t',
-        'feature-test',
-        'claude',
-        'Enter',
-      ])
-      expect(execa).toHaveBeenCalledWith('tmux', [
-        'send-keys',
-        '-t',
-        'feature-test',
-        'echo "hello"',
-        'Enter',
-      ])
-      expect(execa).toHaveBeenCalledWith('tmux', [
-        'send-keys',
-        '-t',
-        'feature-test',
-        'pwd',
-        'Enter',
-      ])
-    })
 
     it('should handle tmux session creation failure', async () => {
       vi.mocked(execa).mockImplementation(async (cmd, args) => {
@@ -168,7 +129,7 @@ describe('create command - edge cases', () => {
 
       // Should not throw error
       await expect(
-        createTmuxSession('feature/test', '/path/to/worktree', config)
+        createTmuxSession('feature/test', '/path/to/worktree')
       ).resolves.not.toThrow()
     })
 
@@ -182,7 +143,7 @@ describe('create command - edge cases', () => {
 
       const config = { claude: { autoStart: false } }
 
-      await createTmuxSession('feature/test@special#chars', '/path/to/worktree', config)
+      await createTmuxSession('feature/test@special#chars', '/path/to/worktree')
 
       expect(execa).toHaveBeenCalledWith('tmux', [
         'has-session',

--- a/src/__tests__/commands/create-enhanced.test.ts
+++ b/src/__tests__/commands/create-enhanced.test.ts
@@ -347,7 +347,6 @@ describe('Create Command - Enhanced Coverage', () => {
       expect(mockExeca).toHaveBeenCalledWith('tmux', ['has-session', '-t', 'test-branch'])
       expect(mockExeca).toHaveBeenCalledTimes(1)
     })
-
   })
 
   describe('handleClaudeMarkdown function', () => {

--- a/src/__tests__/commands/create-enhanced.test.ts
+++ b/src/__tests__/commands/create-enhanced.test.ts
@@ -348,58 +348,6 @@ describe('Create Command - Enhanced Coverage', () => {
       expect(mockExeca).toHaveBeenCalledTimes(1)
     })
 
-    it('should handle Claude Code auto-start', async () => {
-      mockExeca
-        .mockRejectedValueOnce(new Error('Session does not exist'))
-        .mockResolvedValueOnce({ stdout: '' })
-        .mockResolvedValueOnce({ stdout: '' })
-        .mockResolvedValueOnce({ stdout: '' }) // claude command
-        .mockResolvedValueOnce({ stdout: '' }) // initial command
-
-      async function createTmuxSession(branchName: string, worktreePath: string) {
-        const sessionName = branchName.replace(/[^a-zA-Z0-9_-]/g, '-')
-
-        try {
-          try {
-            await execa('tmux', ['has-session', '-t', sessionName])
-            return
-          } catch {
-            // セッション作成
-          }
-
-          await execa('tmux', ['new-session', '-d', '-s', sessionName, '-c', worktreePath])
-          await execa('tmux', ['rename-window', '-t', sessionName, branchName])
-
-          if (config.claude?.autoStart) {
-            await execa('tmux', ['send-keys', '-t', sessionName, 'claude', 'Enter'])
-
-            if (config.claude?.initialCommands) {
-              for (const cmd of config.claude.initialCommands) {
-                await execa('tmux', ['send-keys', '-t', sessionName, cmd, 'Enter'])
-              }
-            }
-          }
-        } catch (error) {
-          // エラーハンドリング
-        }
-      }
-
-      await createTmuxSession('test', '/path', {
-        claude: {
-          autoStart: true,
-          initialCommands: ['echo "hello"'],
-        },
-      })
-
-      expect(mockExeca).toHaveBeenCalledWith('tmux', ['send-keys', '-t', 'test', 'claude', 'Enter'])
-      expect(mockExeca).toHaveBeenCalledWith('tmux', [
-        'send-keys',
-        '-t',
-        'test',
-        'echo "hello"',
-        'Enter',
-      ])
-    })
   })
 
   describe('handleClaudeMarkdown function', () => {

--- a/src/__tests__/commands/create-enhanced.test.ts
+++ b/src/__tests__/commands/create-enhanced.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { execa } from 'execa'
 import fs from 'fs/promises'
 import path from 'path'
@@ -308,7 +308,7 @@ describe('Create Command - Enhanced Coverage', () => {
         }
       }
 
-      await createTmuxSession('feature/test', '/path/to/worktree', {})
+      await createTmuxSession('feature/test', '/path/to/worktree')
 
       expect(mockExeca).toHaveBeenCalledWith('tmux', ['has-session', '-t', 'feature-test'])
       expect(mockExeca).toHaveBeenCalledWith('tmux', [
@@ -330,7 +330,7 @@ describe('Create Command - Enhanced Coverage', () => {
     it('should handle existing tmux session', async () => {
       mockExeca.mockResolvedValueOnce({ stdout: '' }) // has-session succeeds
 
-      async function createTmuxSession(branchName: string, worktreePath: string) {
+      async function createTmuxSession(branchName: string, _worktreePath: string) {
         const sessionName = branchName.replace(/[^a-zA-Z0-9_-]/g, '-')
 
         try {
@@ -342,7 +342,7 @@ describe('Create Command - Enhanced Coverage', () => {
         }
       }
 
-      await createTmuxSession('test-branch', '/path/to/worktree', {})
+      await createTmuxSession('test-branch', '/path/to/worktree')
 
       expect(mockExeca).toHaveBeenCalledWith('tmux', ['has-session', '-t', 'test-branch'])
       expect(mockExeca).toHaveBeenCalledTimes(1)
@@ -430,7 +430,7 @@ Add specific instructions for this worktree here.
       mockPath.join.mockReturnValue('/worktree/CLAUDE.md')
       mockFs.access.mockRejectedValue(new Error('File not found'))
 
-      async function handleClaudeMarkdown(worktreePath: string, config: any) {
+      async function handleClaudeMarkdown(_worktreePath: string, _config: any) {
         try {
           const rootClaudePath = path.join(process.cwd(), 'CLAUDE.md')
           if (

--- a/src/__tests__/commands/create-enhanced.test.ts
+++ b/src/__tests__/commands/create-enhanced.test.ts
@@ -287,7 +287,7 @@ describe('Create Command - Enhanced Coverage', () => {
         .mockResolvedValueOnce({ stdout: '' }) // new-session succeeds
         .mockResolvedValueOnce({ stdout: '' }) // rename-window succeeds
 
-      async function createTmuxSession(branchName: string, worktreePath: string, config: any) {
+      async function createTmuxSession(branchName: string, worktreePath: string) {
         const sessionName = branchName.replace(/[^a-zA-Z0-9_-]/g, '-')
 
         try {
@@ -330,7 +330,7 @@ describe('Create Command - Enhanced Coverage', () => {
     it('should handle existing tmux session', async () => {
       mockExeca.mockResolvedValueOnce({ stdout: '' }) // has-session succeeds
 
-      async function createTmuxSession(branchName: string, worktreePath: string, config: any) {
+      async function createTmuxSession(branchName: string, worktreePath: string) {
         const sessionName = branchName.replace(/[^a-zA-Z0-9_-]/g, '-')
 
         try {
@@ -356,7 +356,7 @@ describe('Create Command - Enhanced Coverage', () => {
         .mockResolvedValueOnce({ stdout: '' }) // claude command
         .mockResolvedValueOnce({ stdout: '' }) // initial command
 
-      async function createTmuxSession(branchName: string, worktreePath: string, config: any) {
+      async function createTmuxSession(branchName: string, worktreePath: string) {
         const sessionName = branchName.replace(/[^a-zA-Z0-9_-]/g, '-')
 
         try {

--- a/src/__tests__/commands/create-simple.test.ts
+++ b/src/__tests__/commands/create-simple.test.ts
@@ -20,7 +20,7 @@ describe('create command simple tests', () => {
     expect(optionNames).toContain('--open')
     expect(optionNames).toContain('--setup')
     expect(optionNames).toContain('--tmux')
-    expect(optionNames).toContain('--claude')
+    expect(optionNames).toContain('--claude-md')
   })
 
   it('should have correct argument configuration', () => {
@@ -43,22 +43,22 @@ describe('create command simple tests', () => {
         env.RUN_SETUP = true
       }
 
-      if (options.claude) {
-        env.CLAUDE_ENABLED = true
+      if (options.claudeMd) {
+        env.CLAUDE_MD_ENABLED = true
       }
 
       return env
     }
 
-    const env1 = setupEnvironment({ open: true, setup: false, claude: true })
+    const env1 = setupEnvironment({ open: true, setup: false, claudeMd: true })
     expect(env1.OPEN_EDITOR).toBe(true)
     expect(env1.RUN_SETUP).toBeUndefined()
-    expect(env1.CLAUDE_ENABLED).toBe(true)
+    expect(env1.CLAUDE_MD_ENABLED).toBe(true)
 
-    const env2 = setupEnvironment({ open: false, setup: true, claude: false })
+    const env2 = setupEnvironment({ open: false, setup: true, claudeMd: false })
     expect(env2.OPEN_EDITOR).toBeUndefined()
     expect(env2.RUN_SETUP).toBe(true)
-    expect(env2.CLAUDE_ENABLED).toBeUndefined()
+    expect(env2.CLAUDE_MD_ENABLED).toBeUndefined()
   })
 
   it('should test worktree path generation', () => {
@@ -327,26 +327,26 @@ This is a git worktree for parallel development.
       if (templateConfig.tmux) {
         processed.tmux = true
       }
-      if (templateConfig.claude) {
-        processed.claude = true
+      if (templateConfig.claudeMd) {
+        processed.claudeMd = true
       }
 
       return processed
     }
 
-    const options = { open: false, setup: false, tmux: false, claude: false }
+    const options = { open: false, setup: false, tmux: false, claudeMd: false }
     const templateConfig = {
       autoSetup: true,
       editor: 'code',
       tmux: true,
-      claude: true,
+      claudeMd: true,
     }
 
     const processed = processTemplateOptions(options, templateConfig)
     expect(processed.setup).toBe(true)
     expect(processed.open).toBe(true)
     expect(processed.tmux).toBe(true)
-    expect(processed.claude).toBe(true)
+    expect(processed.claudeMd).toBe(true)
   })
 
   it('should test parseIssueNumber function', () => {

--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { execa } from 'execa'
 import { createTmuxSession } from '../../commands/create.js'
-import { Config } from '../../core/config.js'
 import { CreateOptions } from '../../types/index.js'
 
 vi.mock('execa')
@@ -10,17 +9,6 @@ vi.mock('../../utils/tmux.js', () => ({
 }))
 
 describe('createTmuxSession - pane split options', () => {
-  const mockConfig: Config = {
-    worktrees: { path: '.git/orchestrations' },
-    development: {
-      autoSetup: true,
-      syncFiles: ['.env'],
-      defaultEditor: 'cursor',
-    },
-    claude: {
-      markdownMode: 'shared',
-    },
-  }
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -9,7 +9,6 @@ vi.mock('../../utils/tmux.js', () => ({
 }))
 
 describe('createTmuxSession - pane split options', () => {
-
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -33,7 +32,6 @@ describe('createTmuxSession - pane split options', () => {
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-l'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
   })
-
 
   it('should create new session with regular --tmux option and auto-attach', async () => {
     const options: CreateOptions = { tmux: true }

--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -29,7 +29,7 @@ describe('createTmuxSession - pane split options', () => {
   it('should split pane horizontally with --tmux-h option', async () => {
     const options: CreateOptions = { tmuxH: true }
 
-    await createTmuxSession('feature-test', '/path/to/worktree', mockConfig, options)
+    await createTmuxSession('feature-test', '/path/to/worktree', options)
 
     expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-h', '-c', '/path/to/worktree'])
 
@@ -39,7 +39,7 @@ describe('createTmuxSession - pane split options', () => {
   it('should split pane vertically with --tmux-v option', async () => {
     const options: CreateOptions = { tmuxV: true }
 
-    await createTmuxSession('feature-test', '/path/to/worktree', mockConfig, options)
+    await createTmuxSession('feature-test', '/path/to/worktree', options)
 
     expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-v', '-c', '/path/to/worktree'])
   })
@@ -49,7 +49,7 @@ describe('createTmuxSession - pane split options', () => {
     const options: CreateOptions = { tmux: true }
     vi.mocked(execa).mockRejectedValueOnce(new Error('no session')) // has-session fails
 
-    await createTmuxSession('feature-test', '/path/to/worktree', mockConfig, options)
+    await createTmuxSession('feature-test', '/path/to/worktree', options)
 
     expect(execa).toHaveBeenCalledWith('tmux', [
       'new-session',
@@ -74,7 +74,7 @@ describe('createTmuxSession - pane split options', () => {
     const originalTmux = process.env.TMUX
     process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
 
-    await createTmuxSession('feature-test', '/path/to/worktree', mockConfig, options)
+    await createTmuxSession('feature-test', '/path/to/worktree', options)
 
     // Should use switch-client instead of attach
     expect(execa).toHaveBeenCalledWith('tmux', ['switch-client', '-t', 'feature-test'], {

--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -11,9 +11,15 @@ vi.mock('../../utils/tmux.js', () => ({
 
 describe('createTmuxSession - pane split options', () => {
   const mockConfig: Config = {
-    worktrees: { root: '.git/orchestrations' },
-    development: {},
-    integrations: {},
+    worktrees: { path: '.git/orchestrations' },
+    development: {
+      autoSetup: true,
+      syncFiles: ['.env'],
+      defaultEditor: 'cursor',
+    },
+    claude: {
+      markdownMode: 'shared',
+    },
   }
 
   beforeEach(() => {
@@ -38,19 +44,6 @@ describe('createTmuxSession - pane split options', () => {
     expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-v', '-c', '/path/to/worktree'])
   })
 
-  it('should send claude command when claude option is enabled', async () => {
-    const options: CreateOptions = { tmuxH: true, claude: true }
-
-    await createTmuxSession('issue-123', '/path/to/worktree', mockConfig, options)
-
-    expect(execa).toHaveBeenCalledWith('tmux', [
-      'send-keys',
-      '-t',
-      ':.',
-      'claude "fix issue 123"',
-      'Enter',
-    ])
-  })
 
   it('should create new session with regular --tmux option and auto-attach', async () => {
     const options: CreateOptions = { tmux: true }

--- a/src/__tests__/commands/create.test.ts
+++ b/src/__tests__/commands/create.test.ts
@@ -253,9 +253,7 @@ describe('create command', () => {
       const worktreePath = '/path/to/worktree'
       const config = {
         claude: {
-          autoStart: false,
           markdownMode: 'shared' as const,
-          initialCommands: [],
         },
       }
 
@@ -279,9 +277,7 @@ describe('create command', () => {
       const worktreePath = '/path/to/worktree'
       const config = {
         claude: {
-          autoStart: false,
           markdownMode: 'shared' as const,
-          initialCommands: [],
         },
       }
 
@@ -298,9 +294,7 @@ describe('create command', () => {
       const worktreePath = '/path/to/worktree'
       const config = {
         claude: {
-          autoStart: false,
           markdownMode: 'split' as const,
-          initialCommands: [],
         },
       }
 
@@ -318,9 +312,7 @@ describe('create command', () => {
       const worktreePath = '/path/to/worktree'
       const config = {
         claude: {
-          autoStart: false,
           markdownMode: 'shared' as const,
-          initialCommands: [],
         },
       }
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -181,7 +181,6 @@ export async function createTmuxSession(
       // tmuxステータスラインを設定
       await setupTmuxStatusLine()
 
-
       // 新しいペインでシェルのプロンプトを表示
       console.log(
         chalk.green(`✅ tmuxペインを${options.tmuxH ? '水平' : '垂直'}分割しました: ${branchName}`)
@@ -205,7 +204,6 @@ export async function createTmuxSession(
     await execa('tmux', ['rename-window', '-t', sessionName, branchName])
 
     console.log(chalk.green(`✨ tmuxセッション '${sessionName}' を作成しました`))
-
 
     // 自動でセッションにアタッチ
     console.log(chalk.cyan(`🎵 tmuxセッション '${sessionName}' にアタッチしています...`))

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -41,9 +41,7 @@ function getHistoryPathForBranch(branchName: string): string {
 }
 
 // 全ての履歴を検索
-async function findAllHistories(
-  gitManager: GitWorktreeManager
-): Promise<ClaudeHistory[]> {
+async function findAllHistories(gitManager: GitWorktreeManager): Promise<ClaudeHistory[]> {
   const histories: ClaudeHistory[] = []
   const worktrees = await gitManager.listWorktrees()
 

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import ora from 'ora'
 import inquirer from 'inquirer'
 import { GitWorktreeManager } from '../core/git.js'
-import { ConfigManager, Config } from '../core/config.js'
+import { ConfigManager } from '../core/config.js'
 import path from 'path'
 import fs from 'fs/promises'
 import { homedir } from 'os'
@@ -32,8 +32,8 @@ function getClaudeHistoryDir(): string {
 }
 
 // ブランチ名から履歴ファイルパスを生成
-function getHistoryPathForBranch(branchName: string, config: Config): string {
-  const template = config.claude?.costOptimization?.historyPath || '~/.claude/history/{branch}.md'
+function getHistoryPathForBranch(branchName: string): string {
+  const template = '~/.claude/history/{branch}.md'
   const expandedPath = template
     .replace('~', homedir())
     .replace('{branch}', branchName.replace(/\//g, '-'))
@@ -42,8 +42,7 @@ function getHistoryPathForBranch(branchName: string, config: Config): string {
 
 // 全ての履歴を検索
 async function findAllHistories(
-  gitManager: GitWorktreeManager,
-  config: Config
+  gitManager: GitWorktreeManager
 ): Promise<ClaudeHistory[]> {
   const histories: ClaudeHistory[] = []
   const worktrees = await gitManager.listWorktrees()
@@ -51,7 +50,7 @@ async function findAllHistories(
   for (const worktree of worktrees) {
     if (!worktree.branch) continue
 
-    const historyPath = getHistoryPathForBranch(worktree.branch, config)
+    const historyPath = getHistoryPathForBranch(worktree.branch)
 
     try {
       const stats = await fs.stat(historyPath)
@@ -270,7 +269,7 @@ async function cleanupHistories(histories: ClaudeHistory[]): Promise<void> {
 }
 
 // 履歴を同期（worktreeパスに移動）
-async function syncHistories(histories: ClaudeHistory[], config: Config): Promise<void> {
+async function syncHistories(histories: ClaudeHistory[]): Promise<void> {
   const spinner = ora('履歴を同期中...').start()
   let syncedCount = 0
 
@@ -278,7 +277,7 @@ async function syncHistories(histories: ClaudeHistory[], config: Config): Promis
     if (!history.worktreePath) continue
 
     // 理想的なパスを計算
-    const idealPath = getHistoryPathForBranch(history.branch, config)
+    const idealPath = getHistoryPathForBranch(history.branch)
 
     if (history.historyPath !== idealPath) {
       try {
@@ -311,10 +310,9 @@ export const historyCommand = new Command('history')
       const gitManager = new GitWorktreeManager()
       const configManager = new ConfigManager()
       await configManager.loadProjectConfig()
-      const config = configManager.getAll()
 
       // 全履歴を検索
-      const histories = await findAllHistories(gitManager, config)
+      const histories = await findAllHistories(gitManager)
 
       if (
         options.list ||
@@ -361,7 +359,7 @@ export const historyCommand = new Command('history')
       }
 
       if (options.sync) {
-        await syncHistories(histories, config)
+        await syncHistories(histories)
       }
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : '不明なエラー'))

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -43,23 +43,8 @@ export const ConfigSchema = z.object({
   // Claude Code統合設定
   claude: z
     .object({
-      // 自動起動
-      autoStart: z.boolean().default(false),
       // CLAUDE.mdの処理方法
       markdownMode: z.enum(['shared', 'split']).default('shared'),
-      // 初期コマンド
-      initialCommands: z.array(z.string()).default([]),
-      // コスト最適化設定
-      costOptimization: z
-        .object({
-          // 停止時の自動コマンド
-          stopHooks: z.array(z.string()).default(['/compact', '/clear']),
-          // 最大出力トークン数
-          maxOutputTokens: z.number().optional(),
-          // セッション履歴の保存先
-          historyPath: z.string().default('~/.claude/history/{branch}.md'),
-        })
-        .optional(),
     })
     .optional(),
 
@@ -120,13 +105,7 @@ const DEFAULT_CONFIG: Config = {
     sessionNaming: '{branch}',
   },
   claude: {
-    autoStart: false,
     markdownMode: 'shared',
-    initialCommands: [],
-    costOptimization: {
-      stopHooks: ['/compact', '/clear'],
-      historyPath: '~/.claude/history/{branch}.md',
-    },
   },
   github: {
     autoFetch: true,
@@ -220,14 +199,7 @@ export class ConfigManager {
         sessionNaming: '{branch}',
       },
       claude: {
-        autoStart: true,
         markdownMode: 'shared',
-        initialCommands: ['/model sonnet-3.5'],
-        costOptimization: {
-          stopHooks: ['/compact', '/clear'],
-          maxOutputTokens: 5000,
-          historyPath: '~/.claude/history/{branch}.md',
-        },
       },
       github: {
         autoFetch: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,7 +28,7 @@ export interface CreateOptions {
   tmuxV?: boolean
   tmuxVertical?: boolean
   tmuxHorizontal?: boolean
-  claude?: boolean
+  claudeMd?: boolean
   yes?: boolean
   shell?: boolean
   exec?: string


### PR DESCRIPTION
## Summary

This PR implements Issue #112 to simplify the `--claude` option by renaming it to `--claude-md` and removing Claude Code auto-start functionality. The changes focus on CLAUDE.md file management only, aligning with maestro's core responsibility of Git worktree management.

## Key Changes

### 1. Renamed Option
- **From**: `--claude` 
- **To**: `--claude-md`
- **Reason**: Clearly indicates this is about CLAUDE.md file management, not Claude Code control

### 2. Removed Features
- ❌ `claude.autoStart` - No more auto-launching Claude in tmux
- ❌ `claude.initialCommands` - No more sending commands to Claude
- ❌ All related tmux send-keys logic for Claude Code

### 3. Simplified Configuration
**Before:**
```json
"claude": {
  "autoStart": true,
  "markdownMode": "shared",
  "initialCommands": ["/model sonnet-3.5"]
}
```

**After:**
```json
"claude": {
  "markdownMode": "shared"
}
```

### 4. Updated Functionality
The `--claude-md` option now only:
- ✅ Creates/manages CLAUDE.md symlinks (shared mode)
- ✅ Creates independent CLAUDE.md files (split mode)
- ❌ Nothing else

## Breaking Changes

⚠️ **This is a breaking change**:
- Existing `--claude` usage must be changed to `--claude-md`
- Claude Code auto-start functionality is removed
- Configuration properties `claude.autoStart` and `claude.initialCommands` are ignored

## Benefits

1. **Clear Scope**: Maestro focuses on Git worktree management only
2. **Less Confusion**: Option name clearly indicates file management
3. **Simpler Codebase**: Removed unnecessary complexity
4. **Better Separation of Concerns**: Let Claude Code handle its own initialization

## Test Plan

- [x] All existing tests updated and passing
- [x] Type checking passes
- [x] Linting passes  
- [x] Build succeeds
- [x] Documentation updated consistently

## Files Modified

### Core Implementation
- `src/types/index.ts` - Updated CreateOptions interface
- `src/core/config.ts` - Simplified config schema
- `src/commands/create.ts` - Renamed option and removed auto-start logic
- `src/commands/history.ts` - Removed unused config dependencies

### Tests
- Updated 5 test files to match new functionality
- Removed obsolete tests for auto-start features

### Documentation
- `README.md` & `README.ja.md` - Updated all references and examples
- `docs/COMMANDS.md` - Updated command reference
- `docs/commands/create.md` - Updated detailed documentation
- `CHANGELOG.md` - Added migration guidance

🤖 Generated with [Claude Code](https://claude.ai/code)