### PR TITLE
docs: Add documentation for claude.markdownMode configuration

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -170,6 +170,10 @@ Maestro が提供する “もう一歩進んだ” 機能を一覧で把握で�
 Maestro は **リポジトリ直下の `.maestro.json`** を読み取り、動作をカスタマイズできます。<br>
 よく使うキーを以下の表にまとめ、完全なサンプルは表に続くコードブロックで確認できます。
 
+**Claude設定:**
+- `markdownMode: "shared"` - メインリポジトリのCLAUDE.mdへのシンボリックリンクを作成（デフォルト）
+- `markdownMode: "split"` - 各worktreeに独立したCLAUDE.mdファイルを作成
+
 | カテゴリ    | 主なキー       | 役割                                    | 例 / デフォルト                     |
 | ----------- | -------------- | --------------------------------------- | ----------------------------------- |
 | worktrees   | `path`         | worktree（演奏者）の格納先              | `.git/orchestra-members`            |
@@ -178,7 +182,7 @@ Maestro は **リポジトリ直下の `.maestro.json`** を読み取り、動�
 |             | `syncFiles`    | 共有したいファイルの配列                | `[".env", ".env.local"]`            |
 | hooks       | `afterCreate`  | 作成後に実行する任意コマンド            | `npm install`                       |
 |             | `beforeDelete` | 削除前フック                            | `echo "Deleting $ORCHESTRA_MEMBER"` |
-| claude      | `markdownMode` | CLAUDE.md ファイル管理モード            | `shared`                            |
+| claude      | `markdownMode` | CLAUDE.md ファイル管理モード            | `shared` (`shared` または `split`)  |
 
 #### 完全なサンプル
 
@@ -198,7 +202,7 @@ Maestro は **リポジトリ直下の `.maestro.json`** を読み取り、動�
     "beforeDelete": "echo \"演奏者を削除します: $ORCHESTRA_MEMBER\""
   },
   "claude": {
-    "markdownMode": "shared"
+    "markdownMode": "shared"  // "shared" | "split"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Need more? Run `mst <command> --help`.
 Maestro reads **`.maestro.json` at the project root** to customise behaviour.<br>
 Key settings are summarised below; a full example follows.
 
+**Claude Configuration:**
+- `markdownMode: "shared"` - Creates symlink to main repository's CLAUDE.md (default)
+- `markdownMode: "split"` - Creates independent CLAUDE.md for each worktree
+
 | Category    | Key            | Purpose                               | Default / Example                   |
 | ----------- | -------------- | ------------------------------------- | ----------------------------------- |
 | worktrees   | `path`         | Where to store performers             | `.git/orchestra-members`            |
@@ -178,7 +182,7 @@ Key settings are summarised below; a full example follows.
 |             | `syncFiles`    | Files to sync across worktrees        | `[".env", ".env.local"]`            |
 | hooks       | `afterCreate`  | Command after creation                | `npm install`                       |
 |             | `beforeDelete` | Command before deletion               | `echo "Deleting $ORCHESTRA_MEMBER"` |
-| claude      | `markdownMode` | CLAUDE.md file management mode       | `shared`                            |
+| claude      | `markdownMode` | CLAUDE.md file management mode       | `shared` (`shared` or `split`)      |
 
 #### Full Example
 
@@ -198,7 +202,7 @@ Key settings are summarised below; a full example follows.
     "beforeDelete": "echo \"Deleting performer: $ORCHESTRA_MEMBER\""
   },
   "claude": {
-    "markdownMode": "shared"
+    "markdownMode": "shared"  // "shared" | "split"
   }
 }
 ```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -776,7 +776,11 @@ Options available for all commands:
 
 ## ⚙️ Configuration File
 
-Customize settings with `mst.config.json`:
+Customize settings with `.maestro.json`:
+
+### Claude Configuration
+- `markdownMode: "shared"` - Creates symlink to main repository's CLAUDE.md (default)
+- `markdownMode: "split"` - Creates independent CLAUDE.md for each worktree
 
 ```json
 {
@@ -797,6 +801,9 @@ Customize settings with `mst.config.json`:
   "hooks": {
     "afterCreate": ["npm install", "npm run setup"],
     "beforeDelete": "echo 'Cleaning up worktree'"
+  },
+  "claude": {
+    "markdownMode": "shared"  // "shared" | "split"
   },
   "integrations": {
     "claude": {

--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -168,9 +168,25 @@ Settings from `.maestro.json` are automatically applied:
   },
   "hooks": {
     "afterCreate": ["npm install", "npm run setup"]
+  },
+  "claude": {
+    "markdownMode": "shared"  // "shared" | "split"
   }
 }
 ```
+
+### Claude Configuration
+
+The `claude.markdownMode` setting controls how CLAUDE.md files are managed:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `"shared"` | Creates symlink to main repository's CLAUDE.md | Share same Claude Code instructions across all worktrees |
+| `"split"` | Creates independent CLAUDE.md for each worktree | Different Claude Code instructions per worktree |
+
+When using `--claude-md` option:
+- `"shared"` mode: Creates a symlink pointing to the main repository's CLAUDE.md
+- `"split"` mode: Creates a new independent CLAUDE.md file in the worktree
 
 ### postCreate Configuration
 


### PR DESCRIPTION
## Summary
- Added comprehensive documentation for the `claude.markdownMode` configuration option
- Updated multiple documentation files to explain the `shared` and `split` modes
- Ensured consistency across English and Japanese documentation

## Changes
- **README.md**: Added explanation of `markdownMode` options in Configuration section
- **README.ja.md**: Added Japanese translation of the documentation
- **docs/COMMANDS.md**: Updated configuration example with claude settings
- **docs/commands/create.md**: Added detailed usage guide with table explaining each mode

## Context
This PR addresses Issue #111, which requested documentation for the `claude.markdownMode` configuration option that was implemented but not documented. This documentation was created after Issue #112 simplified the `--claude` option to `--claude-md`.

## Test plan
- [x] Verified all documentation files are properly formatted
- [x] Ran `pnpm lint` and `pnpm typecheck` - all checks passed
- [x] Ran `pnpm format` to ensure consistent formatting
- [x] Manually reviewed all documentation changes for accuracy

Resolves #111

🤖 Generated with [Claude Code](https://claude.ai/code)