### PR TITLE
feat: --tmux-h/--tmux-v should auto-attach to tmux session when run from terminal (consistent with --tmux)

### DIFF
--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -15,7 +15,7 @@ describe('createTmuxSession - pane split options', () => {
 
   it('should split pane horizontally with --tmux-h option (from inside tmux)', async () => {
     const options: CreateOptions = { tmuxH: true }
-    
+
     // Mock being inside tmux
     const originalTmux = process.env.TMUX
     process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
@@ -25,7 +25,7 @@ describe('createTmuxSession - pane split options', () => {
     expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-h', '-c', '/path/to/worktree'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-l'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
-    
+
     // Restore original TMUX env
     if (originalTmux !== undefined) {
       process.env.TMUX = originalTmux
@@ -36,7 +36,7 @@ describe('createTmuxSession - pane split options', () => {
 
   it('should split pane vertically with --tmux-v option (from inside tmux)', async () => {
     const options: CreateOptions = { tmuxV: true }
-    
+
     // Mock being inside tmux
     const originalTmux = process.env.TMUX
     process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
@@ -46,7 +46,7 @@ describe('createTmuxSession - pane split options', () => {
     expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-v', '-c', '/path/to/worktree'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-l'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
-    
+
     // Restore original TMUX env
     if (originalTmux !== undefined) {
       process.env.TMUX = originalTmux
@@ -144,7 +144,12 @@ describe('createTmuxSession - pane split options', () => {
       ])
 
       // Should rename window
-      expect(execa).toHaveBeenCalledWith('tmux', ['rename-window', '-t', 'feature-test', 'feature-test'])
+      expect(execa).toHaveBeenCalledWith('tmux', [
+        'rename-window',
+        '-t',
+        'feature-test',
+        'feature-test',
+      ])
 
       // Should auto-attach to session
       expect(execa).toHaveBeenCalledWith('tmux', ['attach', '-t', 'feature-test'], {

--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { execa } from 'execa'
 import { createTmuxSession } from '../../commands/create.js'
 import { CreateOptions } from '../../types/index.js'
@@ -13,24 +13,46 @@ describe('createTmuxSession - pane split options', () => {
     vi.clearAllMocks()
   })
 
-  it('should split pane horizontally with --tmux-h option', async () => {
+  it('should split pane horizontally with --tmux-h option (from inside tmux)', async () => {
     const options: CreateOptions = { tmuxH: true }
+    
+    // Mock being inside tmux
+    const originalTmux = process.env.TMUX
+    process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
 
     await createTmuxSession('feature-test', '/path/to/worktree', options)
 
     expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-h', '-c', '/path/to/worktree'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-l'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
+    
+    // Restore original TMUX env
+    if (originalTmux !== undefined) {
+      process.env.TMUX = originalTmux
+    } else {
+      delete process.env.TMUX
+    }
   })
 
-  it('should split pane vertically with --tmux-v option', async () => {
+  it('should split pane vertically with --tmux-v option (from inside tmux)', async () => {
     const options: CreateOptions = { tmuxV: true }
+    
+    // Mock being inside tmux
+    const originalTmux = process.env.TMUX
+    process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
 
     await createTmuxSession('feature-test', '/path/to/worktree', options)
 
     expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-v', '-c', '/path/to/worktree'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-l'])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
+    
+    // Restore original TMUX env
+    if (originalTmux !== undefined) {
+      process.env.TMUX = originalTmux
+    } else {
+      delete process.env.TMUX
+    }
   })
 
   it('should create new session with regular --tmux option and auto-attach', async () => {
@@ -75,5 +97,136 @@ describe('createTmuxSession - pane split options', () => {
     } else {
       delete process.env.TMUX
     }
+  })
+
+  describe('--tmux-h/v from terminal (Issue #116)', () => {
+    beforeEach(() => {
+      // Ensure we're testing outside tmux
+      delete process.env.TMUX
+    })
+
+    it('should create session and split horizontally when --tmux-h from terminal', async () => {
+      const options: CreateOptions = { tmuxH: true }
+      vi.mocked(execa).mockRejectedValueOnce(new Error('no session')) // has-session fails
+
+      await createTmuxSession('feature-test', '/path/to/worktree', options)
+
+      // Should create new session
+      expect(execa).toHaveBeenCalledWith('tmux', [
+        'new-session',
+        '-d',
+        '-s',
+        'feature-test',
+        '-c',
+        '/path/to/worktree',
+      ])
+
+      // Should split window horizontally
+      expect(execa).toHaveBeenCalledWith('tmux', [
+        'split-window',
+        '-t',
+        'feature-test',
+        '-h',
+        '-c',
+        '/path/to/worktree',
+      ])
+
+      // Should focus new pane
+      expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', 'feature-test', '-l'])
+
+      // Should set pane title
+      expect(execa).toHaveBeenCalledWith('tmux', [
+        'select-pane',
+        '-t',
+        'feature-test',
+        '-T',
+        'feature-test',
+      ])
+
+      // Should rename window
+      expect(execa).toHaveBeenCalledWith('tmux', ['rename-window', '-t', 'feature-test', 'feature-test'])
+
+      // Should auto-attach to session
+      expect(execa).toHaveBeenCalledWith('tmux', ['attach', '-t', 'feature-test'], {
+        stdio: 'inherit',
+      })
+    })
+
+    it('should create session and split vertically when --tmux-v from terminal', async () => {
+      const options: CreateOptions = { tmuxV: true }
+      vi.mocked(execa).mockRejectedValueOnce(new Error('no session')) // has-session fails
+
+      await createTmuxSession('feature-test', '/path/to/worktree', options)
+
+      // Should create new session
+      expect(execa).toHaveBeenCalledWith('tmux', [
+        'new-session',
+        '-d',
+        '-s',
+        'feature-test',
+        '-c',
+        '/path/to/worktree',
+      ])
+
+      // Should split window vertically
+      expect(execa).toHaveBeenCalledWith('tmux', [
+        'split-window',
+        '-t',
+        'feature-test',
+        '-v',
+        '-c',
+        '/path/to/worktree',
+      ])
+
+      // Should auto-attach to session
+      expect(execa).toHaveBeenCalledWith('tmux', ['attach', '-t', 'feature-test'], {
+        stdio: 'inherit',
+      })
+    })
+
+    it('should attach to existing session when --tmux-h/v and session exists', async () => {
+      const options: CreateOptions = { tmuxH: true }
+      vi.mocked(execa).mockResolvedValueOnce({ stdout: '', stderr: '' } as any) // has-session succeeds
+
+      await createTmuxSession('feature-test', '/path/to/worktree', options)
+
+      // Should check for existing session
+      expect(execa).toHaveBeenCalledWith('tmux', ['has-session', '-t', 'feature-test'])
+
+      // Should attach to existing session
+      expect(execa).toHaveBeenCalledWith('tmux', ['attach', '-t', 'feature-test'], {
+        stdio: 'inherit',
+      })
+
+      // Should NOT create new session or split
+      expect(execa).not.toHaveBeenCalledWith('tmux', expect.arrayContaining(['new-session']))
+      expect(execa).not.toHaveBeenCalledWith('tmux', expect.arrayContaining(['split-window']))
+    })
+  })
+
+  describe('--tmux-h/v from inside tmux (existing behavior)', () => {
+    beforeEach(() => {
+      // Mock being inside tmux
+      process.env.TMUX = '/tmp/tmux-1000/default,1234,0'
+    })
+
+    afterEach(() => {
+      delete process.env.TMUX
+    })
+
+    it('should only split pane when --tmux-h from inside tmux', async () => {
+      const options: CreateOptions = { tmuxH: true }
+
+      await createTmuxSession('feature-test', '/path/to/worktree', options)
+
+      // Should split window horizontally (existing behavior)
+      expect(execa).toHaveBeenCalledWith('tmux', ['split-window', '-h', '-c', '/path/to/worktree'])
+      expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-l'])
+      expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
+
+      // Should NOT create new session or attach
+      expect(execa).not.toHaveBeenCalledWith('tmux', expect.arrayContaining(['new-session']))
+      expect(execa).not.toHaveBeenCalledWith('tmux', expect.arrayContaining(['attach']))
+    })
   })
 })

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -161,7 +161,7 @@ export async function createTmuxSession(
     // ペイン分割オプションの場合
     if (options?.tmuxH || options?.tmuxV) {
       const isInsideTmux = process.env.TMUX !== undefined
-      
+
       if (!isInsideTmux) {
         // tmux外から実行された場合：新しいセッションを作成
         try {
@@ -176,7 +176,7 @@ export async function createTmuxSession(
 
         // tmuxセッションを作成（detached mode）
         await execa('tmux', ['new-session', '-d', '-s', sessionName, '-c', worktreePath])
-        
+
         // ペイン分割を実行
         const splitArgs = ['split-window', '-t', sessionName]
         if (options.tmuxH) {
@@ -192,15 +192,19 @@ export async function createTmuxSession(
 
         // 新しいペインにタイトルを設定
         await execa('tmux', ['select-pane', '-t', sessionName, '-T', branchName])
-        
+
         // ウィンドウ名を設定
         await execa('tmux', ['rename-window', '-t', sessionName, branchName])
-        
+
         // tmuxステータスラインを設定
         await setupTmuxStatusLine()
-        
-        console.log(chalk.green(`✨ tmuxセッション '${sessionName}' を作成し、ペインを${options.tmuxH ? '水平' : '垂直'}分割しました`))
-        
+
+        console.log(
+          chalk.green(
+            `✨ tmuxセッション '${sessionName}' を作成し、ペインを${options.tmuxH ? '水平' : '垂直'}分割しました`
+          )
+        )
+
         // セッションにアタッチ
         console.log(chalk.cyan(`🎵 tmuxセッション '${sessionName}' にアタッチしています...`))
         await execa('tmux', ['attach', '-t', sessionName], { stdio: 'inherit' })
@@ -229,7 +233,9 @@ export async function createTmuxSession(
 
         // 新しいペインでシェルのプロンプトを表示
         console.log(
-          chalk.green(`✅ tmuxペインを${options.tmuxH ? '水平' : '垂直'}分割しました: ${branchName}`)
+          chalk.green(
+            `✅ tmuxペインを${options.tmuxH ? '水平' : '垂直'}分割しました: ${branchName}`
+          )
         )
         return
       }


### PR DESCRIPTION
## Summary

- Fix `--tmux-h` and `--tmux-v` options to create and auto-attach to tmux session when run from terminal
- Ensure consistent UX across all `--tmux*` options (`--tmux`, `--tmux-h`, `--tmux-v`)
- Maintain existing behavior when run from inside tmux (pane split only)

## Changes

### Implementation
- Modified `createTmuxSession` function in `src/commands/create.ts` to detect terminal vs tmux execution
- Added session creation → pane split → auto-attach workflow for terminal execution
- Preserved existing tmux-inside behavior (pane split only)

### Testing
- Added comprehensive test cases for terminal execution scenario
- Updated existing tests to explicitly cover tmux-inside behavior  
- Verified backward compatibility and session management

## Test Plan

- [x] Terminal execution: `mst create test --tmux-h` creates session and auto-attaches
- [x] Terminal execution: `mst create test --tmux-v` creates session and auto-attaches  
- [x] Tmux execution: `mst create test --tmux-h` splits pane only (existing behavior)
- [x] Existing session handling works correctly
- [x] All tests pass including new comprehensive test suite
- [x] Lint and typecheck pass

## Resolves

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)