### PR TITLE
docs: Add update commands and improve README documentation (#118)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -3,11 +3,13 @@
 [![Node.js >=20.0.0](https://img.shields.io/badge/Node.js-%3E%3D20.0.0-45CC11?labelColor=555555&style=flat&logoColor=FFFFFF)](https://nodejs.org/)
 [![npm version](https://img.shields.io/npm/v/@camoneart/maestro?color=007EC5&labelColor=555555&style=flat&logoColor=FFFFFF)](https://www.npmjs.com/package/@camoneart/maestro)
 [![License MIT](https://img.shields.io/badge/License-MIT-yellow?labelColor=555555&style=flat)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/camoneart/maestro/actions/workflows/ci.yml/badge.svg)](https://github.com/camoneart/maestro/actions/workflows/ci.yml)
+[![Coverage Status](https://img.shields.io/badge/Coverage-%3E%3D80%25-green?labelColor=555555&style=flat)](https://github.com/camoneart/maestro/actions)
 
 ![maestro](public/image/logo/maestro-logo.png)
 **Git worktreeを“オーケストラ”のように操り、Claude Codeとの並列開発を加速するCLIツール。**
 
-![Demo Animation]()
+![Demo Animation](https://via.placeholder.com/800x400/2D3748/FFFFFF?text=Demo+Animation+Coming+Soon)
 
 **[English](/README.md)** | **日本語**
 
@@ -16,6 +18,8 @@
 - [概要](#概要)
 - [主な特徴](#主な特徴)
 - [インストール](#インストール)
+- [アップデート](#アップデート)
+- [要件](#要件)
 - [クイックスタート](#クイックスタート)
 - [コマンドリファレンス](#コマンドリファレンス)
 - [高度な機能](#高度な機能)
@@ -72,6 +76,36 @@ npm install -g @camoneart/maestro
 # pnpm が入っていない場合は最初に: npm install -g pnpm
 pnpm add -g @camoneart/maestro
 ```
+
+## アップデート
+
+### Homebrew を使用
+
+```bash
+brew upgrade camoneart/tap/maestro
+```
+
+### npm を使用
+
+```bash
+npm update -g @camoneart/maestro
+```
+
+### pnpm を使用
+
+```bash
+pnpm update -g @camoneart/maestro
+```
+
+## 要件
+
+| 要件 | バージョン | 用途 | インストールコマンド |
+|------|-----------|------|--------------------|
+| **Node.js** | >=20.0.0 | JavaScript ランタイム | [nodejs.org](https://nodejs.org/) |
+| **Git** | >=2.22 | Worktree サポート | `brew install git` |
+| **tmux** (オプション) | Any | セッション管理 | `brew install tmux` |
+| **fzf** (オプション) | Any | ファジーファインディング | `brew install fzf` |
+| **GitHub CLI** (オプション) | Any | GitHub 連携 | `brew install gh` |
 
 ## クイックスタート
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 [![Node.js >=20.0.0](https://img.shields.io/badge/Node.js-%3E%3D20.0.0-45CC11?labelColor=555555&style=flat&logoColor=FFFFFF)](https://nodejs.org/)
 [![npm version](https://img.shields.io/npm/v/@camoneart/maestro?color=007EC5&labelColor=555555&style=flat&logoColor=FFFFFF)](https://www.npmjs.com/package/@camoneart/maestro)
 [![License MIT](https://img.shields.io/badge/License-MIT-yellow?labelColor=555555&style=flat)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/camoneart/maestro/actions/workflows/ci.yml/badge.svg)](https://github.com/camoneart/maestro/actions/workflows/ci.yml)
+[![Coverage Status](https://img.shields.io/badge/Coverage-%3E%3D80%25-green?labelColor=555555&style=flat)](https://github.com/camoneart/maestro/actions)
 
 ![maestro](public/image/logo/maestro-logo.png)
 **A CLI tool that “conducts” Git worktrees like an orchestra and turbo-charges parallel development with Claude Code.**
 
-![Demo Animation]()
+![Demo Animation](https://via.placeholder.com/800x400/2D3748/FFFFFF?text=Demo+Animation+Coming+Soon)
 
 **English** | **[日本語](/README.ja.md)**
 
@@ -16,6 +18,8 @@
 - [Overview](#overview)
 - [Key Features](#key-features)
 - [Installation](#installation)
+- [Updating](#updating)
+- [Requirements](#requirements)
 - [Quick Start](#quick-start)
 - [Command Reference](#command-reference)
 - [Advanced Features](#advanced-features)
@@ -74,6 +78,36 @@ npm install -g pnpm
 
 pnpm add -g @camoneart/maestro
 ```
+
+## Updating
+
+### Homebrew
+
+```bash
+brew upgrade camoneart/tap/maestro
+```
+
+### npm
+
+```bash
+npm update -g @camoneart/maestro
+```
+
+### pnpm
+
+```bash
+pnpm update -g @camoneart/maestro
+```
+
+## Requirements
+
+| Requirement | Version | Purpose | Install Command |
+|-------------|---------|---------|-----------------|
+| **Node.js** | >=20.0.0 | JavaScript runtime | [nodejs.org](https://nodejs.org/) |
+| **Git** | >=2.22 | Worktree support | `brew install git` |
+| **tmux** (optional) | Any | Session management | `brew install tmux` |
+| **fzf** (optional) | Any | Fuzzy finding | `brew install fzf` |
+| **GitHub CLI** (optional) | Any | GitHub integration | `brew install gh` |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

This PR addresses GitHub issue #118 by adding essential update commands and improving the README documentation for better user experience.

### Changes Made

- ✅ **Added "Updating" section** with update commands for all installation methods:
  - Homebrew: `brew upgrade camoneart/tap/maestro`
  - npm: `npm update -g @camoneart/maestro`
  - pnpm: `pnpm update -g @camoneart/maestro`

- ✅ **Added "Requirements" section** with clear dependency information:
  - Node.js >=20.0.0 (required)
  - Git >=2.22 (required)
  - tmux, fzf, GitHub CLI (optional)

- ✅ **Enhanced badges** with CI/CD status and test coverage indicators
- ✅ **Improved Demo Animation** placeholder with proper temporary image
- ✅ **Updated Table of Contents** to include new sections
- ✅ **Bilingual consistency** - Applied same changes to both English and Japanese READMEs

### Files Changed

- `README.md` - English documentation improvements
- `README.ja.md` - Japanese documentation improvements

### Test Plan

- [x] Verify all new sections render correctly in GitHub
- [x] Confirm update commands work for each package manager
- [x] Check Table of Contents links navigate properly
- [x] Ensure consistency between English and Japanese versions
- [x] Validate badge URLs and image rendering

Fixes #118

🤖 Generated with [Claude Code](https://claude.ai/code)