### PR TITLE
Update version references after v3.2.1 release (Issue #120)

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -9,10 +9,14 @@ The majority of dependencies use the MIT License, which is compatible with this 
 ### Main Dependencies (MIT)
 
 - @modelcontextprotocol/sdk - Model Context Protocol SDK by Anthropic
+- @types/cli-progress - TypeScript definitions for cli-progress
 - chalk - Terminal string styling
+- cli-progress - Easy to use progress-bar for command-line/terminal applications
 - commander - Node.js command-line interfaces
+- conf - Simple config handling for your app or module
 - execa - A better child_process
 - inquirer - Interactive command line user interfaces
+- open - Open stuff like URLs, files, executables
 - ora - Elegant terminal spinner
 - p-limit - Run multiple promise-returning & async functions with limited concurrency
 - simple-git - A light weight interface for running git commands

--- a/scoop/maestro.json
+++ b/scoop/maestro.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.1.0",
+  "version": "3.2.1",
   "description": "Git worktree management tool with Claude Code integration",
   "homepage": "https://github.com/camoneart/maestro",
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "https://registry.npmjs.org/maestro/-/maestro-0.1.0.tgz",
-      "hash": "PLACEHOLDER_SHA256"
+      "url": "https://registry.npmjs.org/maestro/-/maestro-3.2.1.tgz",
+      "hash": "a479b940f9e12ad55d9c4cc4fe1f8f3d0648bdde7acf14230fde5cdb831483a5"
     }
   },
   "depends": "nodejs",
@@ -17,8 +17,14 @@
     "}"
   ],
   "bin": [
-    ["node_modules\\maestro\\dist\\cli.js", "mst"],
-    ["node_modules\\maestro\\dist\\cli.js", "maestro"]
+    [
+      "node_modules\\maestro\\dist\\cli.js",
+      "mst"
+    ],
+    [
+      "node_modules\\maestro\\dist\\cli.js",
+      "maestro"
+    ]
   ],
   "checkver": {
     "url": "https://registry.npmjs.org/maestro/latest",


### PR DESCRIPTION
## Summary
• Update scoop/maestro.json version from 0.1.0 to 3.2.1 with correct SHA256 hash
• Add missing dependencies to THIRD_PARTY_LICENSES.md for legal compliance
• Ensure all version references are synchronized after v3.2.1 release

## Test plan
- [x] Run `pnpm run update-scoop-manifest` to verify automatic manifest update
- [x] Verify bash/zsh/fish completion scripts are up to date via `pnpm run prepublishOnly`
- [x] Confirm all new dependencies are properly documented in license file
- [x] Run lint, typecheck, and format checks

🤖 Generated with [Claude Code](https://claude.ai/code)