### PR TITLE
feat: Auto-cleanup tmux sessions when deleting worktrees (#122)

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,4 +38,5 @@ export interface CreateOptions {
 export interface DeleteOptions {
   force?: boolean
   removeRemote?: boolean
+  keepSession?: boolean
 }


### PR DESCRIPTION
## Summary
- Automatically delete tmux sessions when deleting worktrees with `mst delete`
- Add `--keep-session` option to preserve tmux sessions if needed
- Graceful error handling for cases where tmux sessions don't exist

## Changes
- Enhanced `executeWorktreesDeletion` function to include tmux session cleanup
- Added `keepSession` option to `DeleteOptions` interface
- Comprehensive test coverage for new functionality

## Test plan
- [x] Run existing delete command tests
- [x] Test tmux session deletion with existing sessions
- [x] Test error handling when tmux sessions don't exist
- [x] Test `--keep-session` option functionality
- [x] Test multiple worktree deletion scenarios

Closes #122

🤖 Generated with [Claude Code](https://claude.ai/code)