### PR TITLE
docs: Update documentation for --keep-session option in delete command

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -162,7 +162,7 @@ mst create feature/awesome-feature --tmux --claude-md
 | `init`      | プロジェクト設定を初期化    | `mst init --yes`               |
 | `create`    | 新しい worktree を作成     | `mst create feature/login`     |
 | `list`      | worktree を一覧表示        | `mst list`                     |
-| `delete`    | worktree とローカルブランチを削除 | `mst delete feature/old --fzf` |
+| `delete`    | worktree・ブランチ・tmuxセッションを削除 | `mst delete feature/old --keep-session` |
 | `tmux`      | tmux セッションで開く      | `mst tmux`                     |
 | `sync`      | ファイルをリアルタイム同期 | `mst sync --auto`              |
 | `push`      | Push してPR作成            | `mst push --pr`                |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ See the full [Command Reference](./docs/COMMANDS.md).
 | `init`      | Initialize project config    | `mst init --yes`               |
 | `create`    | Create a new worktree        | `mst create feature/login`     |
 | `list`      | List worktrees               | `mst list`                     |
-| `delete`    | Delete worktree & local branch | `mst delete feature/old --fzf` |
+| `delete`    | Delete worktree, branch & tmux session | `mst delete feature/old --keep-session` |
 | `tmux`      | Open in tmux                 | `mst tmux`                     |
 | `sync`      | Real-time file sync          | `mst sync --auto`              |
 | `push`      | Push and create PR           | `mst push --pr`                |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -220,21 +220,26 @@ mst rm [branch-name] [options]  # alias
 |--------|-------------|
 | `--force`, `-f` | Force delete even with uncommitted changes |
 | `--remove-remote`, `-r` | Also delete remote branch |
+| `--keep-session` | Keep tmux session after deleting worktree |
 | `--fzf` | Select with fzf (multiple selection) |
 | `--current` | Delete current worktree |
 
 #### Features
-- **Complete cleanup**: Automatically deletes both worktree directory and associated local branch
+- **Complete cleanup**: Automatically deletes both worktree directory, associated local branch, and tmux session
+- **tmux Session Management**: Automatically terminates associated tmux sessions (use `--keep-session` to preserve)
 - **Wildcard support**: Use patterns like `"feature/old-*"` to delete multiple branches
 - **Safe deletion**: Uses `git branch -d` to prevent deletion of unmerged branches
 
 #### Examples
 ```bash
-# Basic delete (removes both worktree and local branch)
+# Basic delete (removes worktree, local branch, and tmux session)
 mst delete feature/old-feature
 
 # Force delete (even with uncommitted changes)
 mst delete feature/broken --force
+
+# Keep tmux session after deleting worktree
+mst delete feature/old-feature --keep-session
 
 # Delete with wildcards
 mst delete "feature/old-*"

--- a/docs/commands/delete.md
+++ b/docs/commands/delete.md
@@ -18,8 +18,11 @@ When you delete an orchestra member, Maestro performs a **complete cleanup**:
    - First attempts safe deletion with `git branch -d`
    - Automatically retries with `git branch -D` if the branch is not fully merged
    - Ensures complete cleanup without manual intervention
+3. **tmux session** - The tmux session with the same name as the worktree (if exists)
+   - Automatically terminates the session when deleting the worktree
+   - Use `--keep-session` to preserve the tmux session after deletion
 
-This ensures no orphaned branches remain after worktree deletion.
+This ensures no orphaned branches or sessions remain after worktree deletion.
 
 ## Usage Examples
 
@@ -31,6 +34,9 @@ mst delete feature/old-feature
 
 # Force delete (delete even with uncommitted changes)
 mst delete feature/old-feature --force
+
+# Keep tmux session after deleting worktree
+mst delete feature/old-feature --keep-session
 
 # Select with fzf and delete
 mst delete --fzf
@@ -55,6 +61,7 @@ mst delete --merged --dry-run
 | --------------------- | ----- | -------------------------------------------------- | ------- |
 | `--force`             | `-f`  | Force delete (ignore uncommitted changes)          | `false` |
 | `--remove-remote`     | `-r`  | Also delete remote branch                          | `false` |
+| `--keep-session`      |       | Keep tmux session after deleting worktree         | `false` |
 | `--fzf`               |       | Select with fzf and delete                         | `false` |
 | `--current`           |       | Delete current worktree                            | `false` |
 | `--dry-run`           | `-n`  | Show deletion targets without actually deleting    | `false` |
@@ -113,6 +120,46 @@ mst delete --merged --dry-run
 
 # Actually delete
 mst delete --merged --yes
+```
+
+## tmux Session Management
+
+By default, Maestro automatically cleans up tmux sessions when deleting worktrees to prevent orphaned sessions:
+
+### Default Behavior (Auto-cleanup)
+
+```bash
+# Deletes both worktree and tmux session (if it exists)
+mst delete feature/my-feature
+
+# Example output:
+# ✅ Worktree 'feature/my-feature' deleted
+# ✅ tmux session 'feature/my-feature' terminated
+```
+
+### Preserving tmux Sessions
+
+If you want to keep the tmux session active after deleting the worktree:
+
+```bash
+# Keep tmux session after deleting worktree
+mst delete feature/my-feature --keep-session
+
+# Example output:
+# ✅ Worktree 'feature/my-feature' deleted
+# ℹ️  tmux session 'feature/my-feature' preserved
+```
+
+### Use Cases for --keep-session
+
+- **Continuing work in the same session**: You want to recreate the worktree later but keep your tmux environment
+- **Session has other windows**: Your tmux session contains additional windows/panes you want to preserve
+- **Custom session setup**: The session has been customized with specific layouts or configurations
+
+```bash
+# Example workflow
+mst delete feature/temp-branch --keep-session  # Delete worktree, keep session
+mst create feature/new-branch --tmux           # Create new worktree in existing session
 ```
 
 ## Utilizing Batch Deletion


### PR DESCRIPTION
## Summary

Update documentation for the `--keep-session` option implemented in Issue #122. This PR adds comprehensive documentation for the tmux session management feature in the delete command.

- Add `--keep-session` option to all command reference documentation
- Update command descriptions to reflect tmux session auto-cleanup behavior  
- Add new "tmux Session Management" section with usage examples
- Update both English and Japanese README files

## Changes Made

- ✅ `docs/commands/delete.md` - Added detailed --keep-session documentation and tmux session management section
- ✅ `docs/COMMANDS.md` - Updated delete command reference with --keep-session option
- ✅ `README.md` - Updated English command reference table
- ✅ `README.ja.md` - Updated Japanese command reference table

## Related Issues

- Resolves #124
- Related to #122 (Auto-cleanup tmux sessions when deleting worktrees)

## Test Plan

- [x] Documentation changes reviewed for accuracy
- [x] All command reference tables updated consistently 
- [x] Examples provided for both default and --keep-session behavior
- [x] Both English and Japanese documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)