### PR TITLE
Fix: Prevent worktree self-deletion causing ENOENT error (#126)

### DIFF
--- a/docs/commands/delete.md
+++ b/docs/commands/delete.md
@@ -216,10 +216,12 @@ You can set hooks before and after deletion in `.mst.json`:
 2. **Attempting to delete current orchestra member**
 
    ```
-   Error: Cannot delete the current worktree
+   Error: 現在のディレクトリが削除対象のworktree内にあります。
+   別のディレクトリから実行してください。
+   例: cd .. && mst delete feature/current-branch
    ```
 
-   Solution: Move to another orchestra member before deletion
+   Solution: Move to a different directory (outside the worktree) before deletion
 
 3. **Remote branch still exists**
    ```

--- a/src/__tests__/commands/delete.test.ts
+++ b/src/__tests__/commands/delete.test.ts
@@ -8,6 +8,7 @@ import {
   createMockExecaResponse,
   createMockSpinner,
 } from '../utils/test-helpers'
+import { isCurrentDirectoryInWorktree } from '../../commands/delete'
 
 // モック設定
 vi.mock('../../core/git')
@@ -61,6 +62,38 @@ describe('delete command', () => {
       await gitManager.deleteWorktree('locked-feature', true)
 
       expect(mockGitManager.deleteWorktree).toHaveBeenCalledWith('locked-feature', true)
+    })
+  })
+
+  describe('current directory check', () => {
+    it('should return true when current directory is inside worktree', () => {
+      const originalCwd = process.cwd
+      process.cwd = vi.fn().mockReturnValue('/path/to/worktree/src')
+
+      const result = isCurrentDirectoryInWorktree('/path/to/worktree')
+      expect(result).toBe(true)
+
+      process.cwd = originalCwd
+    })
+
+    it('should return false when current directory is outside worktree', () => {
+      const originalCwd = process.cwd
+      process.cwd = vi.fn().mockReturnValue('/other/path')
+
+      const result = isCurrentDirectoryInWorktree('/path/to/worktree')
+      expect(result).toBe(false)
+
+      process.cwd = originalCwd
+    })
+
+    it('should return false when current directory is parent of worktree', () => {
+      const originalCwd = process.cwd
+      process.cwd = vi.fn().mockReturnValue('/path/to')
+
+      const result = isCurrentDirectoryInWorktree('/path/to/worktree')
+      expect(result).toBe(false)
+
+      process.cwd = originalCwd
     })
   })
 

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -184,6 +184,12 @@ export async function executeWorktreeDeletion(
   }
 }
 
+// 現在のディレクトリが指定されたworktree内にあるかチェック
+export function isCurrentDirectoryInWorktree(worktreePath: string): boolean {
+  const currentDir = process.cwd()
+  return currentDir.startsWith(worktreePath)
+}
+
 // fzfを使用してワークツリーを選択
 async function selectWorktreesWithFzf(
   filteredWorktrees: Worktree[],
@@ -475,6 +481,17 @@ export const deleteCommand = new Command('delete')
         }
 
         spinner.stop()
+
+        // 削除対象のworktree内から削除しようとしているかチェック
+        for (const worktree of targetWorktrees) {
+          if (isCurrentDirectoryInWorktree(worktree.path)) {
+            throw new DeleteCommandError(
+              `現在のディレクトリが削除対象のworktree内にあります。\n` +
+                `別のディレクトリから実行してください。\n` +
+                `例: cd .. && mst delete ${worktree.branch?.replace('refs/heads/', '') || branchName}`
+            )
+          }
+        }
 
         await displayDeletionDetails(targetWorktrees)
 


### PR DESCRIPTION
## Summary
• Fixed issue where deleting a worktree from within itself caused `spawn git ENOENT` error
• Added proper validation to prevent worktree self-deletion attempts
• Enhanced error messages with clear guidance for users

## Problem
When users tried to delete a worktree from within the worktree directory:
1. `git worktree remove` would delete the directory
2. `git branch -d` would fail with `ENOENT` error (current directory no longer exists)
3. Result: Directory deleted but branch remains (inconsistent state)

## Solution
- Added `isCurrentDirectoryInWorktree()` validation function
- Check current directory before deletion execution
- Display helpful error message with correct usage example
- Prevent system inconsistency by catching the issue early

## Test plan
- [x] Added unit tests for directory validation function
- [x] Tested various directory scenarios (inside, outside, parent)
- [x] Verified existing delete functionality remains unchanged
- [x] All tests pass (`pnpm test delete`)
- [x] Code formatting applied (`pnpm format`)

## Changes
- `src/commands/delete.ts`: Added validation logic and error handling
- `src/__tests__/commands/delete.test.ts`: Added comprehensive tests
- `docs/commands/delete.md`: Updated error documentation

Fixes #126

🤖 Generated with [Claude Code](https://claude.ai/code)