### PR TITLE
🚨 Fix: Prevent spinner from hanging when non-existent issue/PR specified (Issue #136)

### DIFF
--- a/src/__tests__/commands/github-error-paths.test.ts
+++ b/src/__tests__/commands/github-error-paths.test.ts
@@ -610,4 +610,149 @@ describe('github command error paths', () => {
       consoleSpy.mockRestore()
     })
   })
+
+  describe('spinner handling on non-existent issue/PR', () => {
+    it('should stop spinner properly when issue does not exist during worktree creation', async () => {
+      mockExeca.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'gh' && args[0] === '--version') {
+          return Promise.resolve(mockGhVersion())
+        }
+        if (cmd === 'gh' && args[0] === 'auth' && args[1] === 'status') {
+          return Promise.resolve(mockGhAuthStatus())
+        }
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view' && args[2] === '999') {
+          throw new Error('no pull requests found')
+        }
+        if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view' && args[2] === '999') {
+          throw new Error('no issues found')
+        }
+        return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 } as any)
+      })
+
+      // oraモックのfailメソッドが呼ばれるかをチェック
+      const { default: ora } = await import('ora')
+      const mockOra = vi.mocked(ora)
+      const mockFail = vi.fn().mockReturnThis()
+      const mockStart = vi.fn().mockReturnThis()
+      mockOra.mockReturnValue({
+        start: mockStart,
+        succeed: vi.fn().mockReturnThis(),
+        fail: mockFail,
+        warn: vi.fn().mockReturnThis(),
+        info: vi.fn().mockReturnThis(),
+        stop: vi.fn().mockReturnThis(),
+        text: '',
+      } as any)
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        await program.parseAsync(['node', 'test', 'github', 'checkout', '999'])
+      } catch (error) {
+        expect(error).toBeDefined()
+      }
+
+      // スピナーのfailメソッドが呼ばれたことを確認
+      expect(mockFail).toHaveBeenCalledWith('情報の取得に失敗しました')
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+
+    it('should stop spinner properly when issue does not exist during comment command', async () => {
+      mockExeca.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'gh' && args[0] === '--version') {
+          return Promise.resolve(mockGhVersion())
+        }
+        if (cmd === 'gh' && args[0] === 'auth' && args[1] === 'status') {
+          return Promise.resolve(mockGhAuthStatus())
+        }
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view' && args[2] === '888') {
+          throw new Error('no pull requests found')
+        }
+        if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view' && args[2] === '888') {
+          throw new Error('no issues found')
+        }
+        return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 } as any)
+      })
+
+      // oraモックのfailメソッドが呼ばれるかをチェック
+      const { default: ora } = await import('ora')
+      const mockOra = vi.mocked(ora)
+      const mockFail = vi.fn().mockReturnThis()
+      const mockStart = vi.fn().mockReturnThis()
+      mockOra.mockReturnValue({
+        start: mockStart,
+        succeed: vi.fn().mockReturnThis(),
+        fail: mockFail,
+        warn: vi.fn().mockReturnThis(),
+        info: vi.fn().mockReturnThis(),
+        stop: vi.fn().mockReturnThis(),
+        text: '',
+      } as any)
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        await program.parseAsync(['node', 'test', 'github', 'comment', '888', '-m', 'test comment'])
+      } catch (error) {
+        expect(error).toBeDefined()
+      }
+
+      // スピナーのfailメソッドが呼ばれたことを確認
+      expect(mockFail).toHaveBeenCalledWith('PR/Issueの確認に失敗しました')
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+
+    it('should stop spinner properly when issue does not exist during interactive comment', async () => {
+      mockExeca.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'gh' && args[0] === '--version') {
+          return Promise.resolve(mockGhVersion())
+        }
+        if (cmd === 'gh' && args[0] === 'auth' && args[1] === 'status') {
+          return Promise.resolve(mockGhAuthStatus())
+        }
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view' && args[2] === '777') {
+          throw new Error('no pull requests found')
+        }
+        if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view' && args[2] === '777') {
+          throw new Error('no issues found')
+        }
+        return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 } as any)
+      })
+
+      mockInquirer.prompt
+        .mockResolvedValueOnce({ selectType: 'comment' })
+        .mockResolvedValueOnce({ inputNumber: '777' })
+        .mockResolvedValueOnce({ comment: 'test comment' })
+
+      // oraモックのfailメソッドが呼ばれるかをチェック
+      const { default: ora } = await import('ora')
+      const mockOra = vi.mocked(ora)
+      const mockFail = vi.fn().mockReturnThis()
+      const mockStart = vi.fn().mockReturnThis()
+      mockOra.mockReturnValue({
+        start: mockStart,
+        succeed: vi.fn().mockReturnThis(),
+        fail: mockFail,
+        warn: vi.fn().mockReturnThis(),
+        info: vi.fn().mockReturnThis(),
+        stop: vi.fn().mockReturnThis(),
+        text: '',
+      } as any)
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        await program.parseAsync(['node', 'test', 'github'])
+      } catch (error) {
+        expect(error).toBeDefined()
+      }
+
+      // スピナーのfailメソッドが呼ばれたことを確認
+      expect(mockFail).toHaveBeenCalledWith('PR/Issueの確認に失敗しました')
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+  })
 })

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -219,8 +219,15 @@ async function openInEditor(
 // コメントコマンドの処理
 async function handleCommentCommand(number: string, options: GithubOptions): Promise<void> {
   const spinner = ora('PR/Issueを確認中...').start()
-  const targetType = await detectType(number)
-  spinner.stop()
+
+  let targetType: 'pr' | 'issue'
+  try {
+    targetType = await detectType(number)
+    spinner.stop()
+  } catch (error) {
+    spinner.fail('PR/Issueの確認に失敗しました')
+    throw error
+  }
 
   // コメント処理
   if (options.message) {
@@ -316,8 +323,15 @@ async function handleInteractiveComment(): Promise<void> {
   ])
 
   const spinner = ora('PR/Issueを確認中...').start()
-  const targetType = await detectType(inputNumber)
-  spinner.stop()
+
+  let targetType: 'pr' | 'issue'
+  try {
+    targetType = await detectType(inputNumber)
+    spinner.stop()
+  } catch (error) {
+    spinner.fail('PR/Issueの確認に失敗しました')
+    throw error
+  }
 
   await addComment(inputNumber, comment, targetType)
 }
@@ -440,9 +454,15 @@ async function createWorktreeFromGithub(
 ): Promise<string> {
   const spinner = ora('情報を取得中...').start()
 
-  // PR/Issueの情報を取得
-  const info = await fetchItemInfo(number, type)
-  spinner.succeed(`${type === 'pr' ? 'PR' : 'Issue'} #${number}: ${info.title}`)
+  let info: ItemInfo
+  try {
+    // PR/Issueの情報を取得
+    info = await fetchItemInfo(number, type)
+    spinner.succeed(`${type === 'pr' ? 'PR' : 'Issue'} #${number}: ${info.title}`)
+  } catch (error) {
+    spinner.fail('情報の取得に失敗しました')
+    throw error
+  }
 
   // ブランチ名を生成
   const branchName = await generateBranchForItem(type, number, info, config)


### PR DESCRIPTION
## Summary
- Fix spinner hanging when non-existent issue/PR number is specified
- Add proper error handling in GitHub command functions
- Ensure spinner.fail() is called to provide clear user feedback

## Problem Description
When trying to create a worktree with a non-existent issue number, the spinner continued to display "Getting information..." after an error occurred, leaving users confused about the command status.

## Changes Made

### Core Implementation
- **`createWorktreeFromGithub` function**: Added try-catch around `fetchItemInfo()` call
- **`handleCommentCommand` function**: Added try-catch around `detectType()` call  
- **`handleInteractiveComment` function**: Added try-catch around `detectType()` call
- All functions now call `spinner.fail()` with appropriate error messages on failure

### Error Handling Improvements
- Proper variable scoping to maintain TypeScript type safety
- Consistent error message patterns across all affected functions
- Error re-throwing to maintain existing error propagation behavior

### Test Coverage
- Added 3 comprehensive test cases covering spinner error handling scenarios
- Tests verify `spinner.fail()` is called with correct error messages
- Tests cover worktree creation, comment commands, and interactive comment flows

## Test Plan
- [x] All existing tests pass
- [x] New tests verify spinner error handling works correctly
- [x] Code passes lint and typecheck validation
- [x] Manual testing confirms spinner stops properly on invalid issue numbers

## Fixed behavior:
- Spinner now properly stops and shows error message when issue/PR doesn't exist
- Users receive clear feedback instead of hanging spinner
- Error messages are consistent and informative

Fixes #136

🤖 Generated with [Claude Code](https://claude.ai/code)