### PR TITLE
🚨 Fix: Prevent spinner hanging when explicit type specified with non-existent issue/PR (Issue #140)

### DIFF
--- a/src/__tests__/commands/github-error-paths.test.ts
+++ b/src/__tests__/commands/github-error-paths.test.ts
@@ -753,7 +753,7 @@ describe('github command error paths', () => {
         expect(error).toBeDefined()
       }
 
-      // Interactive comment has its own spinner handling, similar to comment command  
+      // Interactive comment has its own spinner handling, similar to comment command
       expect(mockFail).toHaveBeenCalledWith('PR/Issueの確認に失敗しました')
       expect(consoleSpy).toHaveBeenCalled()
       consoleSpy.mockRestore()

--- a/src/__tests__/commands/github-error-paths.test.ts
+++ b/src/__tests__/commands/github-error-paths.test.ts
@@ -634,14 +634,16 @@ describe('github command error paths', () => {
       const mockOra = vi.mocked(ora)
       const mockFail = vi.fn().mockReturnThis()
       const mockStart = vi.fn().mockReturnThis()
+      const mockStop = vi.fn().mockReturnThis()
       mockOra.mockReturnValue({
         start: mockStart,
         succeed: vi.fn().mockReturnThis(),
         fail: mockFail,
         warn: vi.fn().mockReturnThis(),
         info: vi.fn().mockReturnThis(),
-        stop: vi.fn().mockReturnThis(),
+        stop: mockStop,
         text: '',
+        isSpinning: false, // Issue #140 fix: spinner is stopped after initialization
       } as any)
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -652,9 +654,9 @@ describe('github command error paths', () => {
         expect(error).toBeDefined()
       }
 
-      // スピナーのfailメソッドが呼ばれたことを確認
-      expect(mockFail).toHaveBeenCalledWith('エラーが発生しました')
-      expect(consoleSpy).toHaveBeenCalled()
+      // Issue #140 fix: When spinner is already stopped, console.error is used instead
+      expect(consoleSpy).toHaveBeenCalledWith(chalk.red('✖ エラーが発生しました'))
+      expect(consoleSpy).toHaveBeenCalledWith(chalk.red('PR/Issue #999 が見つかりません'))
       consoleSpy.mockRestore()
     })
 
@@ -688,6 +690,7 @@ describe('github command error paths', () => {
         info: vi.fn().mockReturnThis(),
         stop: vi.fn().mockReturnThis(),
         text: '',
+        isSpinning: false, // Main spinner is stopped after initialization
       } as any)
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -698,8 +701,8 @@ describe('github command error paths', () => {
         expect(error).toBeDefined()
       }
 
-      // スピナーのfailメソッドが呼ばれたことを確認
-      expect(mockFail).toHaveBeenCalledWith('エラーが発生しました')
+      // Comment command has its own spinner handling, so it calls spinner.fail directly
+      expect(mockFail).toHaveBeenCalledWith('PR/Issueの確認に失敗しました')
       expect(consoleSpy).toHaveBeenCalled()
       consoleSpy.mockRestore()
     })
@@ -739,6 +742,7 @@ describe('github command error paths', () => {
         info: vi.fn().mockReturnThis(),
         stop: vi.fn().mockReturnThis(),
         text: '',
+        isSpinning: false, // Main spinner is stopped after initialization
       } as any)
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -749,8 +753,8 @@ describe('github command error paths', () => {
         expect(error).toBeDefined()
       }
 
-      // スピナーのfailメソッドが呼ばれたことを確認
-      expect(mockFail).toHaveBeenCalledWith('エラーが発生しました')
+      // Interactive comment has its own spinner handling, similar to comment command  
+      expect(mockFail).toHaveBeenCalledWith('PR/Issueの確認に失敗しました')
       expect(consoleSpy).toHaveBeenCalled()
       consoleSpy.mockRestore()
     })

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -717,7 +717,7 @@ export const githubCommand = new Command('github')
         // スピナーが停止済みの場合は直接エラーメッセージを表示
         console.error(chalk.red('✖ エラーが発生しました'))
       }
-      
+
       if (error instanceof GithubCommandError) {
         console.error(chalk.red(error.message))
         process.exitCode = 1

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -122,7 +122,7 @@ async function fetchItemInfo(number: string, type: 'pr' | 'issue'): Promise<Item
   try {
     const result = await execa('gh', [type, 'view', number, '--json', fields])
     return JSON.parse(result.stdout)
-  } catch (error) {
+  } catch {
     const itemName = type === 'pr' ? 'PR' : 'Issue'
     throw new GithubCommandError(`指定した番号の${itemName}は存在しません (#${number})`)
   }


### PR DESCRIPTION
## Summary
- Fix spinner state management in main action catch block to prevent hanging
- Add proper error handling in fetchItemInfo() function with clear error messages
- Improve user experience with specific error messages for non-existent issues/PRs
- Prevent creation of orphaned spinner instances after errors

## Problem Description
Follow-up to #136/#138 - When using explicit type commands like `mst github issue 999` or `mst github pr 999` with non-existent numbers, the spinner would continue to display "情報を取得中..." after the error message, leaving users confused about command status.

## Root Cause Analysis
The issue occurred in the main action's error handling flow:

1. Main spinner starts and stops during initialization (L702)
2. Error occurs in `createWorktreeFromGithub()` → `fetchItemInfo()`
3. Inner spinner properly fails with "情報の取得に失敗しました"
4. Error is re-thrown to main catch block (L707)  
5. **BUG**: Main catch block calls `spinner.fail()` on already-stopped spinner
6. This creates a new orphaned spinner instance that hangs

## Changes Made

### Core Implementation
- **Main Action Error Handling**: Added `spinner.isSpinning` check before calling `spinner.fail()`
- **fetchItemInfo() Function**: Added try-catch with specific error messages
- **createWorktreeFromGithub() Function**: Improved spinner failure messages
- **Error Message Enhancement**: Clear, type-specific error messages

### Detailed Changes
```typescript
// Before: Always called spinner.fail() on potentially stopped spinner
spinner.fail('エラーが発生しました')

// After: Check spinner state first
if (spinner.isSpinning) {
  spinner.fail('エラーが発生しました')
} else {
  console.error(chalk.red('✖ エラーが発生しました'))
}
```

### Error Message Improvements
- **Issue case**: `指定した番号のIssueは存在しません (#999)`
- **PR case**: `指定した番号のPRは存在しません (#999)`
- **Spinner messages**: `Issue #999 が見つかりません` / `PR #999 が見つかりません`

## Test Results

### Before Fix (main branch)
```bash
maestro on main ❯ mst github issue 999   
✖ エラーが発生しました
Command failed with exit code 1: gh issue view 999 --json 'number,title,author'
GraphQL: Could not resolve to an issue or pull request with the number of 999.
⠹ 情報を取得中...  # ← HANGS HERE
```

### After Fix (issue-140 branch)  
```bash
issue-140 ❯ node dist/cli.js github issue 999
- オーケストレーション！
- 情報を取得中...
✖ Issue #999 が見つかりません
✖ エラーが発生しました
指定した番号のIssueは存在しません (#999)
# ← Clean exit, no hanging

issue-140 ❯ node dist/cli.js github pr 999  
- オーケストレーション！
- 情報を取得中...
✖ PR #999 が見つかりません
✖ エラーが発生しました
指定した番号のPRは存在しません (#999)
# ← Clean exit, no hanging
```

## Test Plan
- [x] All existing tests pass
- [x] Manual testing confirms spinner stops properly on invalid issue numbers
- [x] Manual testing confirms spinner stops properly on invalid PR numbers
- [x] Error messages are clear and type-specific
- [x] Code passes lint and typecheck validation

## Fixed Behavior
- Spinner now properly stops and shows clear error message when issue/PR doesn't exist
- Users receive specific feedback instead of hanging spinner  
- Error messages clearly indicate the problem and item type
- No orphaned spinner instances are created

## Implementation Notes
- Maintains backward compatibility with existing error handling
- Preserves all existing functionality while fixing the spinner state issue
- Error messages are user-friendly and actionable
- Solution is minimal and focused on the specific problem

Fixes #140

🤖 Generated with [Claude Code](https://claude.ai/code)