### PR TITLE
fix: Separate user preferences from project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ worktrees/
 .maestro-config.json
 .maestro/
 .maestro-metadata.json
+.maestro.local.json
 
 # Claude Code
 .claude/export-conversations/

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,6 +205,31 @@ Maestro が提供する “もう一歩進んだ” 機能を一覧で把握で�
 Maestro は **リポジトリ直下の `.maestro.json`** を読み取り、動作をカスタマイズできます。<br>
 よく使うキーを以下の表にまとめ、完全なサンプルは表に続くコードブロックで確認できます。
 
+### ⚙️ 設定管理
+
+Maestroはドット記法を使って設定を管理するコマンドを提供します:
+
+```bash
+# 設定値を取得
+mst config get ui.pathDisplay                      # パス表示設定を取得
+mst config get development.autoSetup               # 自動セットアップ設定を取得
+
+# 設定値を設定  
+mst config set ui.pathDisplay relative             # 自動的にユーザー設定として保存
+mst config set --user ui.pathDisplay relative     # 明示的にユーザー設定に保存
+mst config set --project worktrees.path "../"     # 明示的にプロジェクト設定に保存
+mst config set development.defaultEditor cursor    # デフォルトエディタを設定（ユーザー設定）
+
+# デフォルト値にリセット
+mst config reset ui.pathDisplay                    # パス表示をデフォルトにリセット
+mst config reset development.autoSetup             # 自動セットアップをデフォルトにリセット
+
+# 設定ファイルの表示と管理
+mst config show                                    # 現在の有効な設定を表示
+mst config path                                    # 設定ファイルの場所を表示
+mst config init                                    # プロジェクト設定を作成
+```
+
 **Claude設定:**
 - `markdownMode: "shared"` - メインリポジトリのCLAUDE.mdへのシンボリックリンクを作成（デフォルト）
 - `markdownMode: "split"` - 各worktreeに独立したCLAUDE.mdファイルを作成

--- a/README.md
+++ b/README.md
@@ -215,9 +215,10 @@ mst config get ui.pathDisplay                      # Get path display setting
 mst config get development.autoSetup               # Get auto-setup setting
 
 # Set configuration values  
-mst config set ui.pathDisplay relative             # Set path display format
-mst config set development.defaultEditor cursor    # Set default editor
-mst config set worktrees.path "../my-worktrees"    # Set worktrees location
+mst config set ui.pathDisplay relative             # Auto-detects as user setting
+mst config set --user ui.pathDisplay relative     # Explicitly save to user settings
+mst config set --project worktrees.path "../"     # Explicitly save to project settings
+mst config set development.defaultEditor cursor    # Set default editor (user setting)
 
 # Reset to defaults
 mst config reset ui.pathDisplay                    # Reset path display to default

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -542,9 +542,10 @@ mst config get ui.pathDisplay                      # Get path display setting
 mst config get development.autoSetup               # Get auto-setup setting
 
 # Set configuration values
-mst config set ui.pathDisplay relative             # Set path display format
-mst config set development.defaultEditor cursor    # Set default editor
-mst config set worktrees.path "../my-worktrees"    # Set worktrees location
+mst config set ui.pathDisplay relative             # Auto-detects as user setting
+mst config set --user ui.pathDisplay relative     # Explicitly save to user settings
+mst config set --project worktrees.path "../"     # Explicitly save to project settings
+mst config set development.defaultEditor cursor    # Set default editor (user setting)
 
 # Reset to defaults
 mst config reset ui.pathDisplay                    # Reset path display to default
@@ -555,6 +556,8 @@ mst config reset development.autoSetup             # Reset auto-setup to default
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
 | `--global` | `-g` | Target global configuration | `false` |
+| `--user` | `-u` | Target user settings (.maestro.local.json) | `false` |
+| `--project` | `-p` | Target project settings (.maestro.json) | `false` |
 
 ### 🔸 where
 

--- a/src/__tests__/commands/config.test.ts
+++ b/src/__tests__/commands/config.test.ts
@@ -245,9 +245,9 @@ describe('config command', () => {
 
       await configCommand.parseAsync(['node', 'config', 'set', 'ui.pathDisplay', 'relative'])
 
-      expect(mockConfigManager.setConfigValue).toHaveBeenCalledWith('ui.pathDisplay', 'relative')
+      expect(mockConfigManager.setConfigValue).toHaveBeenCalledWith('ui.pathDisplay', 'relative', 'user')
       expect(consoleLogSpy).toHaveBeenCalledWith(
-        chalk.green('✅ ui.pathDisplay を relative に設定しました')
+        chalk.green('✅ ui.pathDisplay を relative に設定しました (ユーザー設定: .maestro.local.json)')
       )
     })
 
@@ -258,7 +258,8 @@ describe('config command', () => {
 
       expect(mockConfigManager.setConfigValue).toHaveBeenCalledWith(
         'development.autoSetup',
-        'false'
+        'false',
+        'project'
       )
     })
 
@@ -267,7 +268,7 @@ describe('config command', () => {
 
       await configCommand.parseAsync(['node', 'config', 'set', 'some.number', '42'])
 
-      expect(mockConfigManager.setConfigValue).toHaveBeenCalledWith('some.number', '42')
+      expect(mockConfigManager.setConfigValue).toHaveBeenCalledWith('some.number', '42', 'project')
     })
 
     it('should handle validation errors', async () => {

--- a/src/__tests__/commands/config.test.ts
+++ b/src/__tests__/commands/config.test.ts
@@ -245,9 +245,15 @@ describe('config command', () => {
 
       await configCommand.parseAsync(['node', 'config', 'set', 'ui.pathDisplay', 'relative'])
 
-      expect(mockConfigManager.setConfigValue).toHaveBeenCalledWith('ui.pathDisplay', 'relative', 'user')
+      expect(mockConfigManager.setConfigValue).toHaveBeenCalledWith(
+        'ui.pathDisplay',
+        'relative',
+        'user'
+      )
       expect(consoleLogSpy).toHaveBeenCalledWith(
-        chalk.green('✅ ui.pathDisplay を relative に設定しました (ユーザー設定: .maestro.local.json)')
+        chalk.green(
+          '✅ ui.pathDisplay を relative に設定しました (ユーザー設定: .maestro.local.json)'
+        )
       )
     })
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -87,17 +87,40 @@ function handleGetAction(configManager: ConfigManager, key?: string): void {
 async function handleSetAction(
   configManager: ConfigManager,
   key?: string,
-  value?: string
+  value?: string,
+  options?: { user?: boolean; project?: boolean }
 ): Promise<void> {
   if (!key || value === undefined) {
     console.error(chalk.red('設定キーと値を指定してください'))
     console.log(chalk.gray('使用例: maestro config set ui.pathDisplay relative'))
+    console.log(chalk.gray('使用例: maestro config set --user ui.pathDisplay relative'))
+    console.log(chalk.gray('使用例: maestro config set --project worktrees.path "../"'))
     return
   }
 
   try {
-    await configManager.setConfigValue(key, value)
-    console.log(chalk.green(`✅ ${key} を ${value} に設定しました`))
+    // ユーザー設定向きの設定かどうかを判定
+    const isUserSetting = key.startsWith('ui.') || key.startsWith('development.defaultEditor')
+    
+    let target: 'user' | 'project'
+    if (options?.user) {
+      target = 'user'
+    } else if (options?.project) {
+      target = 'project'
+    } else {
+      // 自動判定：UI設定はユーザー設定、それ以外はプロジェクト設定
+      target = isUserSetting ? 'user' : 'project'
+    }
+
+    await configManager.setConfigValue(key, value, target)
+    
+    const targetName = target === 'user' ? 'ユーザー設定' : 'プロジェクト設定'
+    const targetFile = target === 'user' ? '.maestro.local.json' : '.maestro.json'
+    console.log(chalk.green(`✅ ${key} を ${value} に設定しました (${targetName}: ${targetFile})`))
+
+    if (target === 'user' && !key.startsWith('ui.') && !key.startsWith('development.defaultEditor')) {
+      console.log(chalk.yellow('⚠️  この設定はプロジェクト全体で共有される設定です。--project フラグの使用を検討してください。'))
+    }
   } catch (error) {
     console.error(chalk.red('設定の更新に失敗しました:'), error)
   }
@@ -134,11 +157,22 @@ function showUsage(): void {
   console.log('  maestro config reset <key>   # 設定値をリセット')
   console.log(chalk.gray('\n使用例:'))
   console.log('  maestro config get ui.pathDisplay')
-  console.log('  maestro config set ui.pathDisplay relative')
-  console.log('  maestro config set development.autoSetup false')
+  console.log('  maestro config set ui.pathDisplay relative        # 自動判定（ユーザー設定）')
+  console.log('  maestro config set --user ui.pathDisplay relative # ユーザー設定（.maestro.local.json）')
+  console.log('  maestro config set --project worktrees.path "../" # プロジェクト設定（.maestro.json）')
   console.log('  maestro config reset ui.pathDisplay')
   console.log(chalk.gray('\nオプション:'))
   console.log('  -g, --global      # グローバル設定を対象にする')
+  console.log('  -u, --user        # ユーザー設定（.maestro.local.json）を対象にする')
+  console.log('  -p, --project     # プロジェクト設定（.maestro.json）を対象にする')
+  console.log(chalk.gray('\n設定カテゴリ:'))
+  console.log(chalk.green('  ユーザー設定（gitignored）:'))
+  console.log('    ui.*              # UI表示設定')
+  console.log('    development.defaultEditor # デフォルトエディタ')
+  console.log(chalk.green('  プロジェクト設定（git追跡）:'))
+  console.log('    worktrees.*       # worktree設定')
+  console.log('    hooks.*           # フック設定')
+  console.log('    claude.*          # Claude統合設定')
 }
 
 export const configCommand = new Command('config')
@@ -147,7 +181,9 @@ export const configCommand = new Command('config')
   .argument('[key]', '設定キー（ドット記法）')
   .argument('[value]', '設定値（setアクションの場合）')
   .option('-g, --global', 'グローバル設定を対象にする')
-  .action(async (action?: string, key?: string, value?: string, options?: { global?: boolean }) => {
+  .option('-u, --user', 'ユーザー設定（.maestro.local.json）を対象にする')
+  .option('-p, --project', 'プロジェクト設定（.maestro.json）を対象にする')
+  .action(async (action?: string, key?: string, value?: string, options?: { global?: boolean; user?: boolean; project?: boolean }) => {
     const configManager = new ConfigManager()
     await configManager.loadProjectConfig()
 
@@ -169,7 +205,7 @@ export const configCommand = new Command('config')
         break
 
       case 'set':
-        await handleSetAction(configManager, key, value)
+        await handleSetAction(configManager, key, value, options)
         break
 
       case 'reset':

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -101,7 +101,7 @@ async function handleSetAction(
   try {
     // ユーザー設定向きの設定かどうかを判定
     const isUserSetting = key.startsWith('ui.') || key.startsWith('development.defaultEditor')
-    
+
     let target: 'user' | 'project'
     if (options?.user) {
       target = 'user'
@@ -113,13 +113,21 @@ async function handleSetAction(
     }
 
     await configManager.setConfigValue(key, value, target)
-    
+
     const targetName = target === 'user' ? 'ユーザー設定' : 'プロジェクト設定'
     const targetFile = target === 'user' ? '.maestro.local.json' : '.maestro.json'
     console.log(chalk.green(`✅ ${key} を ${value} に設定しました (${targetName}: ${targetFile})`))
 
-    if (target === 'user' && !key.startsWith('ui.') && !key.startsWith('development.defaultEditor')) {
-      console.log(chalk.yellow('⚠️  この設定はプロジェクト全体で共有される設定です。--project フラグの使用を検討してください。'))
+    if (
+      target === 'user' &&
+      !key.startsWith('ui.') &&
+      !key.startsWith('development.defaultEditor')
+    ) {
+      console.log(
+        chalk.yellow(
+          '⚠️  この設定はプロジェクト全体で共有される設定です。--project フラグの使用を検討してください。'
+        )
+      )
     }
   } catch (error) {
     console.error(chalk.red('設定の更新に失敗しました:'), error)
@@ -158,8 +166,12 @@ function showUsage(): void {
   console.log(chalk.gray('\n使用例:'))
   console.log('  maestro config get ui.pathDisplay')
   console.log('  maestro config set ui.pathDisplay relative        # 自動判定（ユーザー設定）')
-  console.log('  maestro config set --user ui.pathDisplay relative # ユーザー設定（.maestro.local.json）')
-  console.log('  maestro config set --project worktrees.path "../" # プロジェクト設定（.maestro.json）')
+  console.log(
+    '  maestro config set --user ui.pathDisplay relative # ユーザー設定（.maestro.local.json）'
+  )
+  console.log(
+    '  maestro config set --project worktrees.path "../" # プロジェクト設定（.maestro.json）'
+  )
   console.log('  maestro config reset ui.pathDisplay')
   console.log(chalk.gray('\nオプション:'))
   console.log('  -g, --global      # グローバル設定を対象にする')
@@ -183,36 +195,43 @@ export const configCommand = new Command('config')
   .option('-g, --global', 'グローバル設定を対象にする')
   .option('-u, --user', 'ユーザー設定（.maestro.local.json）を対象にする')
   .option('-p, --project', 'プロジェクト設定（.maestro.json）を対象にする')
-  .action(async (action?: string, key?: string, value?: string, options?: { global?: boolean; user?: boolean; project?: boolean }) => {
-    const configManager = new ConfigManager()
-    await configManager.loadProjectConfig()
+  .action(
+    async (
+      action?: string,
+      key?: string,
+      value?: string,
+      options?: { global?: boolean; user?: boolean; project?: boolean }
+    ) => {
+      const configManager = new ConfigManager()
+      await configManager.loadProjectConfig()
 
-    switch (action) {
-      case 'init':
-        await handleInitAction(configManager)
-        break
+      switch (action) {
+        case 'init':
+          await handleInitAction(configManager)
+          break
 
-      case 'show':
-        await handleShowAction(configManager, options)
-        break
+        case 'show':
+          await handleShowAction(configManager, options)
+          break
 
-      case 'path':
-        await handlePathAction(configManager)
-        break
+        case 'path':
+          await handlePathAction(configManager)
+          break
 
-      case 'get':
-        handleGetAction(configManager, key)
-        break
+        case 'get':
+          handleGetAction(configManager, key)
+          break
 
-      case 'set':
-        await handleSetAction(configManager, key, value, options)
-        break
+        case 'set':
+          await handleSetAction(configManager, key, value, options)
+          break
 
-      case 'reset':
-        await handleResetAction(configManager, key)
-        break
+        case 'reset':
+          await handleResetAction(configManager, key)
+          break
 
-      default:
-        showUsage()
+        default:
+          showUsage()
+      }
     }
-  })
+  )

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -198,11 +198,11 @@ export class ConfigManager {
   // 全設定を取得
   getAll(): Config {
     const globalConfig = this.conf.store
-    return { 
-      ...DEFAULT_CONFIG, 
-      ...globalConfig, 
+    return {
+      ...DEFAULT_CONFIG,
+      ...globalConfig,
       ...(this.projectConfig || {}),
-      ...(this.userConfig || {})
+      ...(this.userConfig || {}),
     }
   }
 
@@ -225,7 +225,11 @@ export class ConfigManager {
   }
 
   // ドット記法で設定値を設定
-  async setConfigValue(keyPath: string, value: unknown, target: 'user' | 'project' = 'project'): Promise<void> {
+  async setConfigValue(
+    keyPath: string,
+    value: unknown,
+    target: 'user' | 'project' = 'project'
+  ): Promise<void> {
     if (target === 'user') {
       await this.setUserConfigValue(keyPath, value)
     } else {
@@ -256,7 +260,7 @@ export class ConfigManager {
       if (!current[key] || typeof current[key] !== 'object') {
         current[key] = {}
       }
-      current = current[key]
+      current = current[key] as Record<string, unknown>
     }
 
     // 値の型変換
@@ -298,7 +302,7 @@ export class ConfigManager {
       if (!current[key] || typeof current[key] !== 'object') {
         current[key] = {}
       }
-      current = current[key]
+      current = current[key] as Record<string, unknown>
     }
 
     // 値の型変換


### PR DESCRIPTION
## Summary
- Add support for `.maestro.local.json` (gitignored) for user-specific settings
- Implement automatic detection for user vs project settings
- Add `--user` and `--project` flags for explicit control

## Problem Solved
When users change personal preferences like `ui.pathDisplay` using `mst config set`, it modifies the project's `.maestro.json` file. This causes:
- Git conflicts when pulling/pushing
- Personal preferences affecting all team members
- Inability to have user-specific settings

## Solution Implementation
### Configuration File Priority
1. `.maestro.local.json` (user preferences, gitignored)
2. `.maestro.json` (project settings)
3. Global config (`~/.config/maestro/`)
4. Default values

### Automatic Detection
The command automatically determines where to save settings:
- **User settings** (saved to `.maestro.local.json`):
  - `ui.*` - UI display preferences
  - `development.defaultEditor` - Personal editor choice
- **Project settings** (saved to `.maestro.json`):
  - `worktrees.*` - Worktree configuration
  - `hooks.*` - Hook settings
  - `claude.*` - Claude integration settings

### Explicit Control
Users can override automatic detection:
```bash
# Force save to user config
mst config set --user worktrees.path "../"

# Force save to project config
mst config set --project ui.pathDisplay relative
```

## Changes Made
- **Core**:
  - `src/core/config.ts`: Added `userConfig` support with proper priority handling
  - Added `setUserConfigValue()` and `setProjectConfigValue()` methods
- **Commands**:
  - `src/commands/config.ts`: Added `--user`/`--project` flags with automatic detection logic
  - Updated help text with clear categorization of settings
- **Project Config**:
  - `.gitignore`: Added `.maestro.local.json`
- **Tests**:
  - Updated config command tests to reflect new behavior
- **Documentation**:
  - Updated all command documentation via command-docs-updater agent

## Test plan
- [x] Run `pnpm test` - all tests pass
- [x] Run `pnpm lint` - no errors (existing warnings only)
- [x] Run `pnpm typecheck` - passes
- [x] Manual testing:
  - [ ] Test automatic detection: `mst config set ui.pathDisplay relative` creates `.maestro.local.json`
  - [ ] Test explicit user flag: `mst config set --user worktrees.path "../"`
  - [ ] Test explicit project flag: `mst config set --project ui.pathDisplay absolute`
  - [ ] Verify `.maestro.local.json` is gitignored
  - [ ] Verify priority order works correctly

Fixes #155

🤖 Generated with [Claude Code](https://claude.ai/code)