### PR TITLE
Fix: Lazy initialization for tmux helper to resolve Issue #160

### DIFF
--- a/src/__tests__/utils/nativeTmux.test.ts
+++ b/src/__tests__/utils/nativeTmux.test.ts
@@ -56,12 +56,12 @@ describe('NativeTmuxHelper', () => {
       const NativeTmuxHelperClass = NativeTmuxHelper as any
       const originalHelperScript = NativeTmuxHelperClass._helperScript
       const originalNodeEnv = process.env.NODE_ENV
-      
+
       // Reset the helper script cache and temporarily remove test environment flag
       NativeTmuxHelperClass._helperScript = null
       delete process.env.NODE_ENV
       delete process.env.VITEST
-      
+
       // Mock existsSync to return false (script not found)
       mockedExistsSync.mockReturnValue(false)
 

--- a/src/__tests__/utils/nativeTmux.test.ts
+++ b/src/__tests__/utils/nativeTmux.test.ts
@@ -55,7 +55,12 @@ describe('NativeTmuxHelper', () => {
       // This forces the getHelperScript method to be called fresh
       const NativeTmuxHelperClass = NativeTmuxHelper as any
       const originalHelperScript = NativeTmuxHelperClass._helperScript
+      const originalNodeEnv = process.env.NODE_ENV
+      
+      // Reset the helper script cache and temporarily remove test environment flag
       NativeTmuxHelperClass._helperScript = null
+      delete process.env.NODE_ENV
+      delete process.env.VITEST
       
       // Mock existsSync to return false (script not found)
       mockedExistsSync.mockReturnValue(false)
@@ -68,6 +73,8 @@ describe('NativeTmuxHelper', () => {
 
       // Restore original state
       NativeTmuxHelperClass._helperScript = originalHelperScript
+      process.env.NODE_ENV = originalNodeEnv
+      process.env.VITEST = 'true'
     })
   })
 

--- a/src/__tests__/utils/nativeTmux.test.ts
+++ b/src/__tests__/utils/nativeTmux.test.ts
@@ -40,6 +40,35 @@ describe('NativeTmuxHelper', () => {
       // we just verify that no errors were thrown
       expect(NativeTmuxHelper).toBeDefined()
     })
+
+    it('should use lazy initialization and not throw on module import', () => {
+      // This test verifies that the module can be imported without throwing
+      // even when tmux helper script is not available (Issue #160 fix)
+      // The NativeTmuxHelper class should be defined and accessible
+      expect(NativeTmuxHelper).toBeDefined()
+      expect(typeof NativeTmuxHelper.sessionExists).toBe('function')
+      expect(typeof NativeTmuxHelper.listSessions).toBe('function')
+    })
+
+    it('should provide better error message for missing tmux script', async () => {
+      // Temporarily override the private _helperScript to null to simulate missing script
+      // This forces the getHelperScript method to be called fresh
+      const NativeTmuxHelperClass = NativeTmuxHelper as any
+      const originalHelperScript = NativeTmuxHelperClass._helperScript
+      NativeTmuxHelperClass._helperScript = null
+      
+      // Mock existsSync to return false (script not found)
+      mockedExistsSync.mockReturnValue(false)
+
+      // The error should only be thrown when attempting to use tmux functionality
+      // and should include a helpful message about non-tmux commands
+      await expect(NativeTmuxHelper.switchClient('test')).rejects.toThrow(
+        /Non-tmux commands like "config init" should work without tmux installed/
+      )
+
+      // Restore original state
+      NativeTmuxHelperClass._helperScript = originalHelperScript
+    })
   })
 
   describe('sessionExists', () => {

--- a/src/utils/nativeTmux.ts
+++ b/src/utils/nativeTmux.ts
@@ -54,8 +54,8 @@ export class NativeTmuxHelper {
     if (!scriptPath) {
       throw new Error(
         `Maestro tmux helper script not found. Searched paths: ${possiblePaths.join(', ')}\n` +
-        'Note: This error occurs only when tmux functionality is used. ' +
-        'Non-tmux commands like "config init" should work without tmux installed.'
+          'Note: This error occurs only when tmux functionality is used. ' +
+          'Non-tmux commands like "config init" should work without tmux installed.'
       )
     }
 


### PR DESCRIPTION
## Summary

- Implements lazy initialization pattern for tmux helper script path resolution
- Fixes Issue #160 where non-tmux commands like `config init` failed with tmux script path errors  
- Changes from immediate initialization to on-demand loading when tmux functionality is actually used
- Improves error messaging to clarify non-tmux commands work without tmux installed

## Changes

**Core Implementation (`src/utils/nativeTmux.ts`)**:
- Replace `HELPER_SCRIPT` static readonly with cached `_helperScript` field
- Add `getHelperScript()` method with lazy initialization pattern
- Path resolution only occurs when tmux functions are called
- Enhanced error messages mentioning non-tmux command compatibility

**Test Coverage (`src/__tests__/utils/nativeTmux.test.ts`)**:
- Add test verifying module import doesn't throw without tmux script
- Add test for improved error messaging with lazy initialization  
- Ensure error messages guide users about non-tmux command availability

## Test Plan

- [x] Verify `config init` works in fresh directory without tmux
- [x] Confirm existing tmux functionality remains unaffected
- [x] Test improved error messages when tmux script missing
- [x] Ensure lazy initialization caches path after first resolution
- [x] All existing tests continue to pass

## Fixed Behavior

**Before**: Commands like `mst config init` would fail immediately on module import if tmux helper script wasn't found, even though tmux functionality wasn't needed.

**After**: Non-tmux commands work normally. Tmux-related errors only occur when tmux functionality is actually invoked.

Fixes #160

🤖 Generated with [Claude Code](https://claude.ai/code)