### PR TITLE
fix: eliminate duplicate error messages when tmux pane creation fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ mst completion fish > ~/.config/fish/completions/mst.fish
 | **fzf not found**                              | fzf not installed                       | `brew install fzf`                |
 | **tmux not found**                             | tmux not installed                      | `brew install tmux`               |
 | **Claude Code won't start**                    | MCP server not running or port conflict | `mst mcp status` → `mst mcp stop` |
-| **Too many tmux panes** <br>`no space for new pane` | Terminal window too small for requested panes | Resize window or use fewer panes |
+| **Too many tmux panes** <br>`画面サイズに対してペイン数（N個）が多すぎます` | Terminal window too small for requested panes | Resize window or use fewer panes |
 
 ### Other error codes
 
@@ -361,7 +361,16 @@ mst completion fish > ~/.config/fish/completions/mst.fish
 
 ### ⚠️ tmux Multi-Pane Troubleshooting
 
-When using multi-pane creation (`--tmux-h-panes` or `--tmux-v-panes`), you may encounter space limitations. Here's how to resolve them:
+When using multi-pane creation (`--tmux-h-panes` or `--tmux-v-panes`), you may encounter space limitations. The create command now provides enhanced error handling with user-friendly Japanese messages:
+
+**Enhanced Error Messages**:
+```bash
+# New Japanese error message format:
+Error: 画面サイズに対してペイン数（4個）が多すぎます。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
+
+# Generic tmux error fallback:
+Error: tmuxペインの作成に失敗しました: [specific error details]
+```
 
 **Quick Solutions**:
 ```bash
@@ -382,6 +391,11 @@ mst create feature/api --tmux-h-panes 4 --tmux-layout tiled
 - **Small (80x24)**: 2-3 panes maximum
 - **Medium (120x40)**: 4-6 panes optimal
 - **Large (200x60+)**: 6+ panes supported
+
+**Error Message Features**:
+- Displays number of panes that couldn't be created
+- Indicates split direction (水平分割 for horizontal, 垂直分割 for vertical)
+- Provides actionable solutions directly in the error message
 
 If the issue persists, search or open a new ticket in the [Issues](https://github.com/camoneart/maestro/issues).
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -132,12 +132,24 @@ mst create feature/api --copy-file .env --copy-file .env.local
 ```
 
 #### Error Handling
-The `create` command includes enhanced error handling for tmux multi-pane creation:
+The `create` command includes enhanced error handling for tmux multi-pane creation with user-friendly Japanese messages:
 
-- **Terminal size errors**: Provides clear guidance when terminal is too small for requested pane count
-- **User-friendly messages**: Shows specific pane count and split type causing the issue
-- **Solution suggestions**: Recommends resizing terminal or reducing pane count
-- **Layout alternatives**: Suggests switching between horizontal/vertical layouts for better space usage
+**Terminal Size Errors**: 
+```
+Error: 画面サイズに対してペイン数（4個）が多すぎます。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
+```
+
+**Generic tmux Errors**:
+```
+Error: tmuxペインの作成に失敗しました: [specific error details]
+```
+
+**Error Message Features**:
+- **Japanese localization**: User-friendly error messages in Japanese
+- **Specific pane count**: Shows exact number of panes that couldn't be created
+- **Split direction indication**: Displays 水平分割 (horizontal) or 垂直分割 (vertical)
+- **Actionable solutions**: Provides immediate guidance in the error message
+- **Debug information**: Preserves original tmux error details for troubleshooting
 
 ### 🔸 push
 
@@ -905,15 +917,29 @@ maestro properly handles the following errors:
 
 ### tmux Multi-Pane Error Handling
 
-The `create` command now provides enhanced error handling for tmux multi-pane creation:
+The `create` command provides enhanced error handling for tmux multi-pane creation with improved user experience:
 
-**Common Error**: Terminal size limitations
-```
-Error: 画面サイズに対してペイン数（4個）が多すぎます。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
-```
+**Enhanced Error Messages**:
+
+1. **Terminal Size Limitations**:
+   ```
+   Error: 画面サイズに対してペイン数（4個）が多すぎます。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
+   ```
+   - **Japanese localization** for better user experience
+   - **Specific pane count** that failed to create
+   - **Split direction** indicator (水平分割/垂直分割)
+   - **Immediate solutions** within the error message
+
+2. **Generic tmux Failures**:
+   ```
+   Error: tmuxペインの作成に失敗しました: [original tmux error message]
+   ```
+   - **Consistent Japanese messaging** across the application
+   - **Preserves original error** details for debugging
+   - **Fallback handler** for all other tmux-related issues
 
 **Quick Solutions**:
-- Resize terminal window
+- Resize terminal window (maximize or drag corners)
 - Reduce pane count: `--tmux-h-panes 2` instead of `--tmux-h-panes 4`
 - Switch split direction: `--tmux-v-panes` instead of `--tmux-h-panes`
 - Use efficient layouts: `--tmux-layout main-vertical` or `--tmux-layout tiled`
@@ -922,6 +948,12 @@ Error: 画面サイズに対してペイン数（4個）が多すぎます。タ
 - Small terminals (80x24): 2-3 panes maximum
 - Medium terminals (120x40): 4-6 panes optimal
 - Large terminals (200x60+): 6+ panes supported
+
+**Error Handling Features**:
+- **Intelligent error parsing** detects specific tmux failure types
+- **Contextual solutions** provided based on error type
+- **Preserves debugging information** while improving user experience
+- **Consistent error formatting** across all commands
 
 If an error occurs, use the `--verbose` option for detailed information.
 

--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -490,7 +490,7 @@ mst create feature/testing --tmux-h-panes 4 --tmux-layout even-horizontal
 
 ### tmux Error Handling
 
-The create command now includes enhanced error handling for tmux pane creation, providing user-friendly messages when terminal space limitations occur:
+The create command includes enhanced error handling for tmux pane creation, providing user-friendly Japanese error messages when issues occur:
 
 4. **No space for new pane error**
 
@@ -499,6 +499,12 @@ The create command now includes enhanced error handling for tmux pane creation, 
    ```
 
    **Cause**: The terminal window is too small to accommodate the requested number of panes with `--tmux-h-panes` or `--tmux-v-panes` options.
+
+   **Error Message Details**:
+   - Displays in Japanese for better user experience
+   - Shows the specific number of panes that failed to create
+   - Indicates whether it was horizontal (水平分割) or vertical (垂直分割) splitting
+   - Provides actionable solutions directly in the error message
 
    **Solutions**:
    - Increase terminal window size by dragging corners or maximizing
@@ -513,6 +519,11 @@ The create command now includes enhanced error handling for tmux pane creation, 
    ```
 
    **Cause**: Various tmux configuration or environment issues.
+
+   **Error Message Features**:
+   - Generic fallback for all other tmux pane creation failures
+   - Preserves the original tmux error message for debugging
+   - Consistent Japanese error messaging across the application
 
    **Solutions**:
    - Ensure tmux is properly installed: `brew install tmux`

--- a/docs/commands/tmux.md
+++ b/docs/commands/tmux.md
@@ -312,12 +312,18 @@ tmux kill-session -t session-name
 
 ### Multi-Pane Creation Errors
 
-When using `mst create` with multi-pane options (`--tmux-h-panes` or `--tmux-v-panes`), you may encounter space-related errors:
+When using `mst create` with multi-pane options (`--tmux-h-panes` or `--tmux-v-panes`), you may encounter space-related errors. The create command now provides enhanced error handling with user-friendly Japanese messages:
 
 4. **No space for new pane**
    ```
    Error: 画面サイズに対してペイン数（4個）が多すぎます。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
    ```
+
+   **Enhanced Error Message Features**:
+   - Displays in Japanese for better user experience
+   - Shows the exact number of panes that couldn't be created
+   - Indicates split direction: 水平分割 (horizontal) or 垂直分割 (vertical)
+   - Provides immediate solutions in the error message itself
 
    **Immediate Solutions**:
    - Resize terminal window (drag corners or maximize)
@@ -334,6 +340,11 @@ When using `mst create` with multi-pane options (`--tmux-h-panes` or `--tmux-v-p
    ```
    Error: tmuxペインの作成に失敗しました: [error details]
    ```
+
+   **Improved Error Handling**:
+   - Generic fallback for all other tmux pane creation failures
+   - Preserves original tmux error message for debugging purposes
+   - Consistent Japanese error messaging throughout the application
 
    **Troubleshooting Steps**:
    ```bash

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -293,9 +293,8 @@ export async function createTmuxSession(
 ): Promise<void> {
   const sessionName = branchName.replace(/[^a-zA-Z0-9_-]/g, '-')
 
-  try {
-    // ペイン分割オプションの場合
-    if (
+  // ペイン分割オプションの場合
+  if (
       options?.tmuxH ||
       options?.tmuxV ||
       options?.tmuxHPanes ||
@@ -409,10 +408,6 @@ export async function createTmuxSession(
       console.log(chalk.white(`   tmux attach -t ${sessionName}`))
       console.log(chalk.gray(`\n💡 ヒント: Ctrl+B, D でセッションからデタッチできます`))
     }
-  } catch (error) {
-    console.error(chalk.red(`tmuxセッションの作成に失敗しました: ${error}`))
-    throw error
-  }
 }
 
 // Claude.mdの処理
@@ -603,11 +598,9 @@ export async function executeCreateCommand(
     }
 
     // その他のエラー
-    console.error(
-      chalk.red(
-        `✖ 演奏者の招集に失敗しました: ${error instanceof Error ? error.message : String(error)}`
-      )
-    )
+    // tmuxエラーの場合はすでにspinner.failで表示済みなので、エラーメッセージのみ表示
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    console.error(chalk.red(`✖ ${errorMessage}`))
     process.exit(1)
   }
 }
@@ -670,7 +663,8 @@ export async function createWorktreeWithProgress(
     // 後処理の実行
     await executePostCreationTasks(worktreePath, branchName, options, config)
   } catch (error) {
-    spinner.fail(chalk.red(`演奏者の招集に失敗しました: ${error}`))
+    // spinnerを失敗状態にするが、エラーメッセージは上位層で処理
+    spinner.fail(chalk.red('演奏者の招集に失敗しました'))
     throw error
   }
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -295,119 +295,119 @@ export async function createTmuxSession(
 
   // ペイン分割オプションの場合
   if (
-      options?.tmuxH ||
-      options?.tmuxV ||
-      options?.tmuxHPanes ||
-      options?.tmuxVPanes ||
-      options?.tmuxLayout
-    ) {
-      const isInsideTmux = process.env.TMUX !== undefined
+    options?.tmuxH ||
+    options?.tmuxV ||
+    options?.tmuxHPanes ||
+    options?.tmuxVPanes ||
+    options?.tmuxLayout
+  ) {
+    const isInsideTmux = process.env.TMUX !== undefined
 
-      if (!isInsideTmux) {
-        // 既存セッションチェック
-        try {
-          await execa('tmux', ['has-session', '-t', sessionName])
-          console.log(chalk.yellow(`tmuxセッション '${sessionName}' は既に存在します`))
-          await attachToTmuxSession(sessionName)
-          return
-        } catch {
-          // セッションが存在しない場合は作成
-        }
+    if (!isInsideTmux) {
+      // 既存セッションチェック
+      try {
+        await execa('tmux', ['has-session', '-t', sessionName])
+        console.log(chalk.yellow(`tmuxセッション '${sessionName}' は既に存在します`))
+        await attachToTmuxSession(sessionName)
+        return
+      } catch {
+        // セッションが存在しない場合は作成
+      }
 
-        await handleNewSessionPaneSplit(sessionName, branchName, worktreePath, options)
+      await handleNewSessionPaneSplit(sessionName, branchName, worktreePath, options)
 
-        const { paneCountMsg, splitTypeMsg, layoutMsg } = generateTmuxMessage(options)
-        console.log(
-          chalk.green(
-            `✨ tmuxセッション '${sessionName}' を作成し、${paneCountMsg}${splitTypeMsg}分割しました${layoutMsg}`
-          )
+      const { paneCountMsg, splitTypeMsg, layoutMsg } = generateTmuxMessage(options)
+      console.log(
+        chalk.green(
+          `✨ tmuxセッション '${sessionName}' を作成し、${paneCountMsg}${splitTypeMsg}分割しました${layoutMsg}`
         )
+      )
 
-        // アタッチメント処理
-        if (process.stdout.isTTY && process.stdin.isTTY) {
-          const { shouldAttach } = await inquirer.prompt([
-            {
-              type: 'confirm',
-              name: 'shouldAttach',
-              message: 'セッションにアタッチしますか？',
-              default: true,
-            },
-          ])
+      // アタッチメント処理
+      if (process.stdout.isTTY && process.stdin.isTTY) {
+        const { shouldAttach } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'shouldAttach',
+            message: 'セッションにアタッチしますか？',
+            default: true,
+          },
+        ])
 
-          if (shouldAttach) {
-            console.log(chalk.cyan(`🎵 tmuxセッション '${sessionName}' にアタッチしています...`))
-            await attachToTmuxSession(sessionName)
-          } else {
-            console.log(chalk.yellow(`\n📝 後でアタッチするには以下のコマンドを実行してください:`))
-            console.log(chalk.white(`   tmux attach -t ${sessionName}`))
-            console.log(chalk.gray(`\n💡 ヒント: Ctrl+B, D でセッションからデタッチできます`))
-          }
+        if (shouldAttach) {
+          console.log(chalk.cyan(`🎵 tmuxセッション '${sessionName}' にアタッチしています...`))
+          await attachToTmuxSession(sessionName)
         } else {
-          console.log(
-            chalk.yellow(`\n📝 tmuxセッションにアタッチするには以下のコマンドを実行してください:`)
-          )
+          console.log(chalk.yellow(`\n📝 後でアタッチするには以下のコマンドを実行してください:`))
           console.log(chalk.white(`   tmux attach -t ${sessionName}`))
           console.log(chalk.gray(`\n💡 ヒント: Ctrl+B, D でセッションからデタッチできます`))
         }
-        return
       } else {
-        await handleInsideTmuxPaneSplit(branchName, worktreePath, options)
-
-        const { paneCountMsg, splitTypeMsg, layoutMsg } = generateTmuxMessage(options)
         console.log(
-          chalk.green(
-            `✅ tmuxペインを${paneCountMsg}${splitTypeMsg}分割しました${layoutMsg}: ${branchName}`
-          )
+          chalk.yellow(`\n📝 tmuxセッションにアタッチするには以下のコマンドを実行してください:`)
         )
-        return
-      }
-    }
-
-    // 通常のtmuxセッション作成
-    try {
-      await execa('tmux', ['has-session', '-t', sessionName])
-      console.log(chalk.yellow(`tmuxセッション '${sessionName}' は既に存在します`))
-      return
-    } catch {
-      // セッションが存在しない場合は作成
-    }
-
-    const shell = process.env.SHELL || '/bin/bash'
-    await execa('tmux', ['new-session', '-d', '-s', sessionName, '-c', worktreePath, shell, '-l'])
-
-    await execa('tmux', ['rename-window', '-t', sessionName, branchName])
-    console.log(chalk.green(`✨ tmuxセッション '${sessionName}' を作成しました`))
-
-    if (process.stdout.isTTY && process.stdin.isTTY) {
-      const { shouldAttach } = await inquirer.prompt([
-        {
-          type: 'confirm',
-          name: 'shouldAttach',
-          message: 'セッションにアタッチしますか？',
-          default: true,
-        },
-      ])
-
-      if (shouldAttach) {
-        console.log(chalk.cyan(`🎵 tmuxセッション '${sessionName}' にアタッチしています...`))
-        const isInsideTmux = process.env.TMUX !== undefined
-        if (isInsideTmux) {
-          await switchTmuxClient(sessionName)
-        } else {
-          await attachToTmuxSession(sessionName)
-        }
-      } else {
-        console.log(chalk.yellow(`\n📝 後でアタッチするには以下のコマンドを実行してください:`))
         console.log(chalk.white(`   tmux attach -t ${sessionName}`))
         console.log(chalk.gray(`\n💡 ヒント: Ctrl+B, D でセッションからデタッチできます`))
       }
+      return
     } else {
+      await handleInsideTmuxPaneSplit(branchName, worktreePath, options)
+
+      const { paneCountMsg, splitTypeMsg, layoutMsg } = generateTmuxMessage(options)
       console.log(
-        chalk.yellow(`\n📝 tmuxセッションにアタッチするには以下のコマンドを実行してください:`)
+        chalk.green(
+          `✅ tmuxペインを${paneCountMsg}${splitTypeMsg}分割しました${layoutMsg}: ${branchName}`
+        )
       )
+      return
+    }
+  }
+
+  // 通常のtmuxセッション作成
+  try {
+    await execa('tmux', ['has-session', '-t', sessionName])
+    console.log(chalk.yellow(`tmuxセッション '${sessionName}' は既に存在します`))
+    return
+  } catch {
+    // セッションが存在しない場合は作成
+  }
+
+  const shell = process.env.SHELL || '/bin/bash'
+  await execa('tmux', ['new-session', '-d', '-s', sessionName, '-c', worktreePath, shell, '-l'])
+
+  await execa('tmux', ['rename-window', '-t', sessionName, branchName])
+  console.log(chalk.green(`✨ tmuxセッション '${sessionName}' を作成しました`))
+
+  if (process.stdout.isTTY && process.stdin.isTTY) {
+    const { shouldAttach } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'shouldAttach',
+        message: 'セッションにアタッチしますか？',
+        default: true,
+      },
+    ])
+
+    if (shouldAttach) {
+      console.log(chalk.cyan(`🎵 tmuxセッション '${sessionName}' にアタッチしています...`))
+      const isInsideTmux = process.env.TMUX !== undefined
+      if (isInsideTmux) {
+        await switchTmuxClient(sessionName)
+      } else {
+        await attachToTmuxSession(sessionName)
+      }
+    } else {
+      console.log(chalk.yellow(`\n📝 後でアタッチするには以下のコマンドを実行してください:`))
       console.log(chalk.white(`   tmux attach -t ${sessionName}`))
       console.log(chalk.gray(`\n💡 ヒント: Ctrl+B, D でセッションからデタッチできます`))
     }
+  } else {
+    console.log(
+      chalk.yellow(`\n📝 tmuxセッションにアタッチするには以下のコマンドを実行してください:`)
+    )
+    console.log(chalk.white(`   tmux attach -t ${sessionName}`))
+    console.log(chalk.gray(`\n💡 ヒント: Ctrl+B, D でセッションからデタッチできます`))
+  }
 }
 
 // Claude.mdの処理


### PR DESCRIPTION
## Summary
- Fixed issue #163 where duplicate error messages were displayed when tmux pane creation failed
- Removed redundant error logging at multiple levels
- Updated documentation to reflect enhanced error handling

## Changes
- **Source Code**: Simplified error propagation in `createTmuxSession()`, `createWorktreeWithProgress()`, and `executeCreateCommand()`
- **Documentation**: Updated error handling sections in create.md, tmux.md, README.md, and COMMANDS.md with Japanese error message details

## Test plan
- [x] Verify single error message display when tmux pane creation fails
- [x] Test error handling with various terminal sizes and pane counts
- [x] Confirm documentation accurately reflects current error behavior
- [x] Run linting and type checking to ensure code quality

Closes #163

🤖 Generated with [Claude Code](https://claude.ai/code)