### PR TITLE
🐛 fix: tmuxペインタイトル設定とフォーカス位置のバグ修正 (Issue #167)

### DIFF
--- a/src/__tests__/commands/create-tmux.test.ts
+++ b/src/__tests__/commands/create-tmux.test.ts
@@ -47,7 +47,9 @@ describe('createTmuxSession - pane split options', () => {
       '-l',
     ])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '0'])
-    expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
+    // Verify that titles are set for each pane individually (Issue #167 fix)
+    expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '0', '-T', 'feature-test'])
+    expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '1', '-T', 'feature-test'])
 
     // Restore original TMUX env
     if (originalTmux !== undefined) {
@@ -75,7 +77,9 @@ describe('createTmuxSession - pane split options', () => {
       '-l',
     ])
     expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '0'])
-    expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
+    // Verify that titles are set for each pane individually (Issue #167 fix)
+    expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '0', '-T', 'feature-test'])
+    expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '1', '-T', 'feature-test'])
 
     // Restore original TMUX env
     if (originalTmux !== undefined) {
@@ -212,11 +216,18 @@ describe('createTmuxSession - pane split options', () => {
       // Should focus first pane
       expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', 'feature-test:0'])
 
-      // Should set pane title
+      // Should set pane titles for all panes individually (Issue #167 fix)
       expect(execa).toHaveBeenCalledWith('tmux', [
         'select-pane',
         '-t',
+        'feature-test:0',
+        '-T',
         'feature-test',
+      ])
+      expect(execa).toHaveBeenCalledWith('tmux', [
+        'select-pane',
+        '-t',
+        'feature-test:1',
         '-T',
         'feature-test',
       ])
@@ -311,7 +322,9 @@ describe('createTmuxSession - pane split options', () => {
         '-l',
       ])
       expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '0'])
-      expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-T', 'feature-test'])
+      // Verify that titles are set for each pane individually (Issue #167 fix)
+      expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '0', '-T', 'feature-test'])
+      expect(execa).toHaveBeenCalledWith('tmux', ['select-pane', '-t', '1', '-T', 'feature-test'])
 
       // Should NOT create new session or attach
       expect(execa).not.toHaveBeenCalledWith('tmux', expect.arrayContaining(['new-session']))

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -246,15 +246,11 @@ async function setTitleForAllPanes(
   paneCount: number
 ): Promise<void> {
   for (let i = 0; i < paneCount; i++) {
-    const selectArgs = sessionName
-      ? ['select-pane', '-t', `${sessionName}:${i}`]
-      : ['select-pane', '-t', `${i}`]
-
     try {
-      await execa('tmux', selectArgs)
+      // 各ペインに直接タイトルを設定
       const titleArgs = sessionName
-        ? ['select-pane', '-t', sessionName, '-T', branchName]
-        : ['select-pane', '-T', branchName]
+        ? ['select-pane', '-t', `${sessionName}:${i}`, '-T', branchName]
+        : ['select-pane', '-t', `${i}`, '-T', branchName]
       await execa('tmux', titleArgs)
     } catch {
       // ペインが存在しない場合はスキップ


### PR DESCRIPTION
## 概要

Issue #165の修正（v3.5.4）が不完全で、tmuxペインタイトルが全ペインに設定されず、最後のペインにのみ設定される回帰バグを修正しました。

## 修正内容

### 1. ペインタイトル設定の修正
- `setTitleForAllPanes`関数で各ペインに個別にタイトルを設定するよう修正
- `sessionName:${i}`形式で各ペインを正確に指定

**Before (バグ):**
```typescript
const titleArgs = sessionName
  ? ['select-pane', '-t', sessionName, '-T', branchName]
  : ['select-pane', '-T', branchName]
```

**After (修正):**
```typescript
const titleArgs = sessionName
  ? ['select-pane', '-t', `${sessionName}:${i}`, '-T', branchName]
  : ['select-pane', '-t', `${i}`, '-T', branchName]
```

### 2. テストの更新
- 修正後の動作に合わせてテストケースを更新
- Issue #167の修正を検証するテストを追加

## 動作確認

✅ 全てのテストが通過（974 passed | 47 skipped）
✅ 全ペインに統一したブランチ名タイトルが設定される
✅ フォーカスが最初のペイン（0番）に正しく移動する

## 関連Issue

Fixes #167
Related to #165

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>