### PR TITLE
feat: Add automatic empty directory cleanup after worktree deletion

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -163,7 +163,7 @@ mst create feature/awesome-feature --tmux --claude-md
 | `init`      | プロジェクト設定を初期化    | `mst init --yes`               |
 | `create`    | 新しい worktree を作成     | `mst create feature/login`     |
 | `list`      | worktree を一覧表示        | `mst list`                     |
-| `delete`    | worktree・ブランチ・tmuxセッションを削除 | `mst delete feature/old --keep-session` |
+| `delete`    | worktree削除と空ディレクトリのクリーンアップ | `mst delete feature/old --keep-session` |
 | `tmux`      | tmux セッションで開く      | `mst tmux`                     |
 | `sync`      | ファイルをリアルタイム同期 | `mst sync --auto`              |
 | `push`      | Push してPR作成            | `mst push --pr`                |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ![Demo Animation](https://via.placeholder.com/800x400/2D3748/FFFFFF?text=Demo+Animation+Coming+Soon)
 
-**English** | **[日本語](/README.ja.md)**
+**English** | **[Japanese](/README.ja.md)**
 
 ## Table of Contents
 
@@ -165,7 +165,7 @@ See the full [Command Reference](./docs/COMMANDS.md).
 | `init`      | Initialize project config    | `mst init --yes`               |
 | `create`    | Create a new worktree        | `mst create feature/login`     |
 | `list`      | List worktrees               | `mst list`                     |
-| `delete`    | Delete worktree, branch & tmux session | `mst delete feature/old --keep-session` |
+| `delete`    | Delete worktree & cleanup empty directories | `mst delete feature/old --keep-session` |
 | `tmux`      | Open in tmux                 | `mst tmux`                     |
 | `sync`      | Real-time file sync          | `mst sync --auto`              |
 | `push`      | Push and create PR           | `mst push --pr`                |
@@ -360,8 +360,8 @@ Maestro includes **intelligent automatic rollback functionality** that prevents 
 mst create feature/new-feature --tmux
 
 # Maestro automatically cleans up:
-⚠️  後処理でエラーが発生したため、作成したリソースをクリーンアップします...
-✅ クリーンアップが完了しました
+⚠️  An error occurred during post-processing. Cleaning up created resources...
+✅ Cleanup completed
 ```
 
 **Benefits:**
@@ -377,7 +377,7 @@ mst create feature/new-feature --tmux
 | **fzf not found**                              | fzf not installed                       | `brew install fzf`                |
 | **tmux not found**                             | tmux not installed                      | `brew install tmux`               |
 | **Claude Code won't start**                    | MCP server not running or port conflict | `mst mcp status` → `mst mcp stop` |
-| **Too many tmux panes** <br>`画面サイズに対してペイン数（N個）が多すぎるため、セッションが作成できませんでした` | Terminal window too small for requested panes | Resize window or reduce panes (max: 10 horizontal, 15 vertical) |
+| **Too many tmux panes** <br>`Unable to create session with N panes due to terminal size` | Terminal window too small for requested panes | Resize window or reduce panes (max: 10 horizontal, 15 vertical) |
 
 ### Other error codes
 
@@ -399,7 +399,7 @@ Maestro now includes **early validation for tmux pane creation** to prevent reso
 **Enhanced Error Messages**:
 ```bash
 # Early validation error message:
-Error: 画面サイズに対してペイン数（20個）が多すぎるため、セッションが作成できませんでした。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
+Error: Unable to create session with 20 panes due to terminal size. Please resize your terminal window or reduce the number of panes. (horizontal split)
 
 # Command exits immediately - no resources created
 ```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -148,8 +148,8 @@ The `create` command includes **intelligent automatic rollback functionality** t
 mst create feature/new-feature --tmux
 
 # Automatic rollback output:
-⚠️  後処理でエラーが発生したため、作成したリソースをクリーンアップします...
-✅ クリーンアップが完了しました
+⚠️  An error occurred during post-processing. Cleaning up created resources...
+✅ Cleanup completed
 ```
 
 **Benefits:**
@@ -170,7 +170,7 @@ The `create` command now includes **early validation for tmux pane creation** to
 **Enhanced Error Messages**:
 ```bash
 # Early validation error message:
-Error: 画面サイズに対してペイン数（20個）が多すぎるため、セッションが作成できませんでした。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
+Error: Unable to create session with 20 panes due to terminal size. Please resize your terminal window or reduce the number of panes. (horizontal split)
 
 # Command exits immediately - no resources created
 ```
@@ -292,13 +292,14 @@ mst rm [branch-name] [options]  # alias
 
 #### Features
 - **Complete cleanup**: Automatically deletes both worktree directory, associated local branch, and tmux session
+- **Empty directory cleanup**: Automatically removes empty parent directories (useful for branches like `feature/api` which leave empty `feature/` directories)
 - **tmux Session Management**: Automatically terminates associated tmux sessions (use `--keep-session` to preserve)
 - **Wildcard support**: Use patterns like `"feature/old-*"` to delete multiple branches
 - **Safe deletion**: Uses `git branch -d` to prevent deletion of unmerged branches
 
 #### Examples
 ```bash
-# Basic delete (removes worktree, local branch, and tmux session)
+# Basic delete (removes worktree, local branch, tmux session, and empty directories)
 mst delete feature/old-feature
 
 # Force delete (even with uncommitted changes)
@@ -753,9 +754,9 @@ mst graph
 mst graph --format dot --output graph.dot
 
 # When circular dependencies are detected, warnings are automatically shown:
-# ⚠️  循環参照が検出されました:
+# ⚠️  Circular reference detected:
 #   - feature-a → feature-b → feature-c → feature-a
-# 循環参照のあるブランチは main から派生するよう調整されました
+# Branches with circular references have been adjusted to derive from main
 ```
 
 ### 🔸 history
@@ -966,7 +967,7 @@ The `create` command now includes **early validation for tmux pane creation** to
 **Enhanced Error Messages**:
 ```bash
 # Early validation error message:
-Error: 画面サイズに対してペイン数（20個）が多すぎるため、セッションが作成できませんでした。ターミナルウィンドウを大きくするか、ペイン数を減らしてください。（水平分割）
+Error: Unable to create session with 20 panes due to terminal size. Please resize your terminal window or reduce the number of panes. (horizontal split)
 
 # Command exits immediately - no resources created
 ```

--- a/docs/commands/delete.md
+++ b/docs/commands/delete.md
@@ -14,15 +14,19 @@ mst rm <branch-name> [options]  # alias
 When you delete an orchestra member, Maestro performs a **complete cleanup**:
 
 1. **Worktree directory** - The physical directory containing the branch's files
-2. **Local branch** - The Git branch associated with the worktree
+2. **Empty parent directories** - Any empty directories left behind after worktree deletion
+   - Automatically cleans up empty parent directories (useful for branches like `feature/api` which would leave empty `feature/` directory)
+   - Recursively removes empty directories up to the repository base directory
+   - Provides visual feedback showing which directories were cleaned up with the message: `🧹 Removed empty directory: {directory-name}`
+3. **Local branch** - The Git branch associated with the worktree
    - First attempts safe deletion with `git branch -d`
    - Automatically retries with `git branch -D` if the branch is not fully merged
    - Ensures complete cleanup without manual intervention
-3. **tmux session** - The tmux session with the same name as the worktree (if exists)
+4. **tmux session** - The tmux session with the same name as the worktree (if exists)
    - Automatically terminates the session when deleting the worktree
    - Use `--keep-session` to preserve the tmux session after deletion
 
-This ensures no orphaned branches or sessions remain after worktree deletion.
+This ensures no orphaned branches, sessions, or empty directories remain after worktree deletion.
 
 ## Usage Examples
 
@@ -80,6 +84,7 @@ Normally, a confirmation prompt is displayed before deletion. The path display f
 
    ⚠️  This will delete:
    • Worktree directory and all its contents
+   • Any empty parent directories (e.g., empty 'feature/' directory)
    • Local branch 'feature/old-feature'
 
    This action cannot be undone.
@@ -96,6 +101,7 @@ Normally, a confirmation prompt is displayed before deletion. The path display f
 
    ⚠️  This will delete:
    • Worktree directory and all its contents
+   • Any empty parent directories (e.g., empty 'feature/' directory)
    • Local branch 'feature/old-feature'
 
    This action cannot be undone.
@@ -151,6 +157,7 @@ mst delete feature/my-feature
 
 # Example output:
 # ✅ Worktree 'feature/my-feature' deleted
+# 🧹 Removed empty directory: feature
 # ✅ tmux session 'feature/my-feature' terminated
 ```
 
@@ -164,6 +171,7 @@ mst delete feature/my-feature --keep-session
 
 # Example output:
 # ✅ Worktree 'feature/my-feature' deleted
+# 🧹 Removed empty directory: feature
 # ℹ️  tmux session 'feature/my-feature' preserved
 ```
 
@@ -233,9 +241,9 @@ You can set hooks before and after deletion in `.mst.json`:
 2. **Attempting to delete current orchestra member**
 
    ```
-   Error: 現在のディレクトリが削除対象のworktree内にあります。
-   別のディレクトリから実行してください。
-   例: cd .. && mst delete feature/current-branch
+   Error: Current directory is inside the worktree to be deleted.
+   Please run from a different directory.
+   Example: cd .. && mst delete feature/current-branch
    ```
 
    Solution: Move to a different directory (outside the worktree) before deletion


### PR DESCRIPTION
## Summary
- Implement automatic cleanup of empty parent directories when deleting worktrees
- Add visual feedback showing which directories were cleaned up
- Ensure safe operation that stops at repository base directory

## Changes
- Add `cleanupEmptyDirectories()` method to `GitWorktreeManager` class
- Recursively remove empty directories up to repository base after worktree deletion
- Display `🧹 Removed empty directory: {directory-name}` message for each cleaned directory
- Add comprehensive test coverage for various scenarios including:
  - Basic empty directory cleanup
  - Skipping non-empty directories
  - Nested directory cleanup
  - Stopping at base directory boundary
  - Error handling

## Test plan
- [x] Unit tests added with 100% coverage for the new functionality
- [x] Manual testing with various branch structures (feature/api, feature/deep/nested/branch)
- [x] Verified cleanup stops at repository base directory
- [x] Confirmed error handling doesn't break deletion process

Fixes #175

🤖 Generated with [Claude Code](https://claude.ai/code)