### PR TITLE
fix: set pane title for regular --tmux sessions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -135,7 +135,7 @@ mst create feature/awesome-feature --tmux --claude-md
 #### ポイント
 
 - `mst shell <ブランチ名>` でいつでも演奏者に入れます（省略すると fzf で選択）。
-- `--tmux` を付けると専用 tmux セッションを作成してアタッチを確認し（非TTY環境では自動アタッチ）、`--claude-md` を併用すると Claude Code ワークスペースファイルを設定します。
+- `--tmux` を付けると専用 tmux セッションをブランチ名タイトル付きで作成してアタッチを確認し（非TTY環境では自動アタッチ）、`--claude-md` を併用すると Claude Code ワークスペースファイルを設定します。
 - `--tmux-h`/`--tmux-v` は現在の tmux ペインを水平/垂直分割し、新しいペインに自動フォーカスして即座に開発開始できます。
 - `--tmux-h-panes <数>`/`--tmux-v-panes <数>` は指定数の水平/垂直ペインを作成します。
 - `--tmux-layout <種類>` は特定の tmux レイアウト（even-horizontal、even-vertical、main-horizontal、main-vertical、tiled）を適用します。

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ mst create feature/awesome-feature --tmux --claude-md
 #### Tips
 
 - `mst shell <branch>` lets you enter any performer after creation (fzf prompt when omitted).
-- `--tmux` creates a dedicated tmux session and prompts for attachment (automatically attaches in non-TTY environments); combine with `--claude-md` to set up Claude Code workspace files.
+- `--tmux` creates a dedicated tmux session with branch name title and prompts for attachment (automatically attaches in non-TTY environments); combine with `--claude-md` to set up Claude Code workspace files.
 - `--tmux-h`/`--tmux-v` splits the current tmux pane horizontally/vertically with improved focus management (focuses first pane) and unified pane titles.
 - `--tmux-h-panes <number>`/`--tmux-v-panes <number>` creates multiple horizontal/vertical panes with specified count, all displaying consistent branch name titles.
 - `--tmux-layout <type>` applies specific tmux layout (even-horizontal, even-vertical, main-horizontal, main-vertical, tiled).

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -94,7 +94,7 @@ mst create <branch-name> [options]
 | `--base <branch>` | Specify base branch (default: main) |
 | `--open` | Automatically open in editor |
 | `--setup` | Auto-setup development environment |
-| `--tmux` | Create tmux session with attachment prompt (TTY) or auto-attach (non-TTY) |
+| `--tmux` | Create tmux session with branch name title and attachment prompt (TTY) or auto-attach (non-TTY) |
 | `--tmux-h` | Create in horizontal tmux pane split (preserves shell environment) |
 | `--tmux-v` | Create in vertical tmux pane split (preserves shell environment) |
 | `--tmux-h-panes <number>` | Create specified number of horizontal tmux panes |

--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -97,7 +97,7 @@ Retrieved information:
 
 ### Session Creation with Interactive Attachment
 
-Using the `--tmux` option creates a new tmux session and prompts for attachment:
+Using the `--tmux` option creates a new tmux session with branch name title and prompts for attachment:
 
 ```bash
 # Creates session and prompts for attachment
@@ -114,6 +114,7 @@ mst create feature/new-feature --tmux
   - If outside tmux: Attaches using `tmux attach`
   - If inside tmux: Switches using `tmux switch-client`
 - **Shell Environment**: Sessions are created with login shells to inherit your custom PS1 prompts, environment variables, and shell configuration files
+- **Pane Titles**: The tmux pane is automatically titled with the branch name for easy identification
 
 ### Pane Splitting (when already in tmux)
 

--- a/docs/commands/tmux.md
+++ b/docs/commands/tmux.md
@@ -60,6 +60,7 @@ The command integrates with tmux to provide:
 - **Window management**: Creates new windows or splits panes as needed
 - **Worktree navigation**: Changes directory to selected worktree
 - **Environment setup**: Sets appropriate environment variables
+- **Pane Titles**: All tmux panes are automatically titled with branch names for consistent identification (applies to both regular sessions and multi-pane splits)
 
 ### Session Information
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -422,6 +422,8 @@ export async function createTmuxSession(
     await execa('tmux', ['new-session', '-d', '-s', sessionName, '-c', worktreePath, shell, '-l'])
 
     await execa('tmux', ['rename-window', '-t', sessionName, branchName])
+    // ペインタイトルを設定
+    await setTitleForAllPanes(sessionName, branchName, 1)
     console.log(chalk.green(`✨ tmuxセッション '${sessionName}' を作成しました`))
 
     if (process.stdout.isTTY && process.stdin.isTTY) {


### PR DESCRIPTION
## Summary
- Fixed issue where tmux pane titles weren't being set when using the `--tmux` option
- Added `setTitleForAllPanes()` call for regular tmux session creation
- Updated all related documentation to reflect this fix

## Test plan
- [x] Built the project successfully with `pnpm build`
- [x] Tested `mst create test --tmux` - pane title correctly shows "test"
- [x] Tested `mst create test --tmux-h` - both panes correctly show "test" 
- [x] Ran `pnpm lint` - no new errors
- [x] Ran `pnpm typecheck` - no type errors
- [x] Ran `pnpm format` - code is properly formatted

Fixes #177

🤖 Generated with [Claude Code](https://claude.ai/code)