### PR TITLE
fix: github command now only opens editor with explicit --open flag

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -416,7 +416,7 @@ mst gh [type] [number] [options]  # alias
 #### Options
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--open` | `-o` | Open in editor |
+| `--open` | `-o` | Open in editor (only when explicitly specified) |
 | `--setup` | `-s` | Execute environment setup |
 | `--message <message>` | `-m` | Comment message |
 | `--reopen` | | Reopen PR/Issue |
@@ -447,6 +447,8 @@ mst github 123 --tmux-v
 # Add comment to PR/Issue
 mst github comment 123 -m "LGTM!"
 ```
+
+**Note:** The `--open` flag only opens the editor when explicitly specified. The GitHub command does not automatically open in the editor based on `development.defaultEditor` configuration.
 
 ### 🔸 tmux
 

--- a/docs/commands/github.md
+++ b/docs/commands/github.md
@@ -44,7 +44,7 @@ mst github 123 --tmux-v
 # Create and open in horizontal split
 mst github 123 --tmux-h
 
-# Create with automatic setup
+# Create with automatic setup and explicitly open in editor
 mst github 123 --open --setup
 ```
 
@@ -52,7 +52,7 @@ mst github 123 --open --setup
 
 | Option                | Short      | Description                              | Default |
 | --------------------- | ---------- | ---------------------------------------- | ------- |
-| `--open`              | `-o`       | Open in editor after creation            | `false` |
+| `--open`              | `-o`       | Open in editor after creation (only when explicitly specified) | `false` |
 | `--setup`             | `-s`       | Execute environment setup                | `false` |
 | `--message <message>` | `-m`       | Comment message (for comment subcommand) | none    |
 | `--reopen`            |            | Reopen PR/Issue                          | `false` |
@@ -60,6 +60,10 @@ mst github 123 --open --setup
 | `--tmux`              | `-t`       | Open in new tmux window                  | `false` |
 | `--tmux-vertical`     | `--tmux-v` | Open in vertical split pane              | `false` |
 | `--tmux-horizontal`   | `--tmux-h` | Open in horizontal split pane            | `false` |
+
+### Editor Opening Behavior
+
+The `--open` flag only opens the editor when explicitly specified. Unlike some other commands, the GitHub command does not automatically open in the editor based on the `development.defaultEditor` configuration setting. You must use the `--open` flag to open the created worktree in your editor.
 
 ## Listing GitHub Items
 

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -609,17 +609,14 @@ async function processWorktreeCreation(
         )
       )
       console.log(chalk.yellow('エディタでのオープンに進みます...'))
-      // tmuxが失敗した場合はエディタオープンにフォールバック
-      const shouldOpen =
-        options?.open ||
-        (options?.open === undefined && config.development?.defaultEditor !== 'none')
-      await openInEditor(worktreePath, config, !!shouldOpen)
+      // tmuxが失敗した場合はエディタオープンにフォールバック（-oフラグが明示的に指定された場合のみ）
+      if (options?.open) {
+        await openInEditor(worktreePath, config, true)
+      }
     }
-  } else {
-    // エディタで開く
-    const shouldOpen =
-      options?.open || (options?.open === undefined && config.development?.defaultEditor !== 'none')
-    await openInEditor(worktreePath, config, !!shouldOpen)
+  } else if (options?.open) {
+    // エディタで開く（-oフラグが明示的に指定された場合のみ）
+    await openInEditor(worktreePath, config, true)
   }
 
   console.log(chalk.green('\n✨ GitHub統合による演奏者の招集が完了しました！'))


### PR DESCRIPTION
## Summary

- Modified `github` command to require explicit `--open` flag to open editor
- Previously would auto-open if `defaultEditor` was configured in `.maestro.json`
- Now consistent with `create` command behavior

## Problem

The `github` command was automatically opening the editor when `defaultEditor` was configured, even without the `--open` flag. This was inconsistent with the `create` command which requires an explicit `--open` flag.

## Changes

1. **Modified editor opening logic** in `src/commands/github.ts`:
   - Removed automatic opening based on `defaultEditor` configuration
   - Now only opens when `--open` flag is explicitly provided
   - Applied fix to both normal flow and tmux fallback flow

2. **Updated documentation**:
   - `docs/commands/github.md` - Clarified `--open` flag behavior
   - `docs/COMMANDS.md` - Updated command reference

## Testing

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [ ] Manual testing of `mst github issue` without `-o` flag
- [ ] Manual testing of `mst github issue -o` with flag

## Breaking Change

This is a minor breaking change for users who relied on the automatic editor opening behavior. Users will now need to explicitly use the `--open` flag to open the editor after creating a worktree from GitHub issues/PRs.

Fixes #184

🤖 Generated with [Claude Code](https://claude.ai/code)