### PR TITLE
fix: prevent interactive mode when non-existent Issue/PR number is specified

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -354,6 +354,7 @@ mst completion fish > ~/.config/fish/completions/mst.fish
 | **tmux が見つからない**                   | tmux 未インストール              | `brew install tmux`               |
 | **Claude Code が起動しない**              | MCP サーバー未起動 or ポート競合 | `mst mcp status` → `mst mcp stop` |
 | **tmux ペインが多すぎる**<br>`画面サイズに対してペイン数（N個）が多すぎるため、セッションが作成できませんでした` | ターミナルウィンドウに対してペイン数が過多 | ウィンドウのリサイズまたはペイン数を削減（最大：水平10個、垂直15個） |
+| **GitHub PR/Issue が見つからない**<br>`Error: PR/Issue #999 が見つかりません` | 存在しないIssue/PR番号を指定 | 正しい番号を確認するか、リポジトリを確認 |
 
 ### その他のエラーコード例
 

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ mst create feature/new-feature --tmux
 | **tmux not found**                             | tmux not installed                      | `brew install tmux`               |
 | **Claude Code won't start**                    | MCP server not running or port conflict | `mst mcp status` → `mst mcp stop` |
 | **Too many tmux panes** <br>`Unable to create session with N panes due to terminal size` | Terminal window too small for requested panes | Resize window or reduce panes (max: 10 horizontal, 15 vertical) |
+| **GitHub PR/Issue not found** <br>`Error: PR/Issue #999 が見つかりません` | Specified non-existent Issue/PR number | Check correct number or verify repository |
 
 ### Other error codes
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -458,6 +458,8 @@ The GitHub command uses an optimized process for creating worktrees from Pull Re
 
 **Note:** The `--open` flag only opens the editor when explicitly specified. The GitHub command does not automatically open in the editor based on `development.defaultEditor` configuration.
 
+**Improved Error Handling (v3.5.14+)**: Fixed issue #195 where specifying a non-existent Issue/PR number would incorrectly enter interactive mode. The command now validates the existence of the specified PR/Issue first and displays a clear error message if not found.
+
 ### 🔸 tmux
 
 Manage orchestra members with tmux sessions.

--- a/docs/commands/github.md
+++ b/docs/commands/github.md
@@ -206,6 +206,12 @@ mst github issue issue-456
 mst github
 ```
 
+Interactive mode is triggered when:
+- No arguments are provided (`mst github`)
+- The command is run without specifying a PR/Issue number
+
+Note: Interactive mode will NOT be triggered if a specific PR/Issue number is provided but doesn't exist. In such cases, an error message is displayed instead.
+
 Displayed menu:
 
 ```
@@ -333,10 +339,12 @@ done
 2. **PR/Issue not found**
 
    ```
-   Error: Pull request #999 not found
+   Error: PR/Issue #999 が見つかりません
    ```
 
-   Solution: Check correct number or verify repository is correct
+   Solution: Check correct number or verify repository is correct. When a specific PR/Issue number is provided but doesn't exist, the command now properly displays an error message and exits instead of entering interactive selection mode.
+
+   **Improved Behavior (v3.5.14+)**: Fixed issue #195 where specifying a non-existent Issue/PR number would incorrectly enter interactive mode. The command now validates the existence of the specified PR/Issue first and displays a clear error message if not found, preventing unintended interactive prompts.
 
 3. **Orchestra member already exists**
    ```

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -513,6 +513,11 @@ async function createWorktreeFromGithub(
 // ====== 引数解析 ======
 
 function parseArguments(type?: string, number?: string): { type?: string; number?: string } {
+  // typeが数値の場合（maestro github 123）
+  if (type && !isNaN(parseInt(type)) && !number) {
+    return { type: undefined, number: type }
+  }
+
   // typeとnumberの正規化
   if (!type || type === 'checkout') {
     // checkout または引数なしの場合
@@ -520,11 +525,6 @@ function parseArguments(type?: string, number?: string): { type?: string; number
       console.error(chalk.red('PR/Issue番号を指定してください'))
       console.log(chalk.gray('使い方: maestro github checkout <number>'))
       process.exit(1)
-    }
-
-    // typeが番号の場合（maestro github 123）
-    if (type && !isNaN(parseInt(type))) {
-      return { type: 'checkout', number: type }
     }
   }
 
@@ -650,6 +650,7 @@ async function executeGithubCommand(
   let finalType = type
   let finalNumber = number
 
+
   if (!finalNumber) {
     try {
       const result = await handleInteractiveMode()
@@ -661,11 +662,12 @@ async function executeGithubCommand(
       }
       throw error
     }
-  }
-
-  // typeの自動判定（明示的にpr/issueが指定された場合はスキップ）
-  if (finalType === 'checkout' || !finalType) {
-    finalType = await detectType(finalNumber!)
+  } else {
+    // 番号が指定されている場合、まず存在チェックを行う
+    // typeの自動判定（明示的にpr/issueが指定された場合はスキップ）
+    if (finalType === 'checkout' || !finalType) {
+      finalType = await detectType(finalNumber)
+    }
   }
 
   await processWorktreeCreation(
@@ -717,10 +719,10 @@ export const githubCommand = new Command('github')
 
       if (error instanceof GithubCommandError) {
         console.error(chalk.red(error.message))
-        process.exitCode = 1
+        process.exit(1)
       } else {
         console.error(chalk.red(error instanceof Error ? error.message : '不明なエラー'))
-        process.exitCode = 1
+        process.exit(1)
       }
     }
   })


### PR DESCRIPTION
## Summary
- Fixed a bug where specifying a non-existent Issue/PR number would incorrectly enter interactive mode
- Now properly shows error message and exits when PR/Issue is not found
- Improved argument parsing to correctly handle numeric-only arguments

## Test plan
- [x] Run `mst github 99999` - should show error "PR/Issue #99999 が見つかりません"
- [x] Run `mst github pr 99999` - should show error "指定した番号のPRは存在しません (#99999)"
- [x] Run `mst github issue 99999` - should show error "指定した番号のIssueは存在しません (#99999)"
- [x] All tests pass with `pnpm test src/__tests__/commands/github.test.ts`
- [x] No new lint/typecheck errors

Fixes #195

🤖 Generated with [Claude Code](https://claude.ai/code)