### PR TITLE
fix: prevent unnecessary selection prompt in github issue/pr commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -435,8 +435,14 @@ mst gh list
 mst github checkout 123
 mst gh 123  # shorthand
 
-# Create from Issue #456
+# Create from Issue #456 (shows Issue list directly)
 mst github issue 456
+
+# Create from PR (shows PR list directly)  
+mst github pr 123
+
+# Interactive selection (shows type selection prompt)
+mst github
 
 # Create and open in tmux
 mst github 123 --tmux

--- a/docs/commands/github.md
+++ b/docs/commands/github.md
@@ -7,6 +7,13 @@ Command to create orchestra members (Git worktrees) directly from GitHub Issues 
 ```bash
 mst github [type] [number] [options]
 mst gh [type] [number] [options]  # alias
+
+# Direct type selection (no type selection prompt)
+mst github pr [number]    # Shows PR list directly
+mst github issue [number] # Shows Issue list directly
+
+# Full interactive mode (shows type selection prompt)
+mst github               # Shows "What would you like to summon performers from?"
 ```
 
 ## Usage Examples
@@ -22,10 +29,13 @@ mst gh list
 mst github checkout 123
 mst gh 123  # shorthand
 
-# Create orchestra member from Issue
+# Create orchestra member from Issue (shows Issue list directly)
 mst github issue 456
 
-# Interactive selection
+# Create orchestra member from PR (shows PR list directly)
+mst github pr 123
+
+# Interactive selection (shows type selection first)
 mst github
 
 # Add comment to PR/Issue
@@ -168,10 +178,10 @@ This approach ensures reliable PR worktree creation by properly handling the bas
 ### Basic Flow
 
 ```bash
-# 1. Check Issue list
-gh issue list
+# 1. Check Issue list using maestro
+mst github list
 
-# 2. Create orchestra member from Issue
+# 2. Create orchestra member from Issue (shows Issue list directly)
 mst github issue 456
 
 # 3. Branch name is auto-generated
@@ -201,24 +211,42 @@ mst github issue issue-456
 
 ## Interactive Mode
 
+The GitHub command supports different interaction modes depending on how it's invoked:
+
+### Direct Type Selection
+
+When the type is explicitly specified, it directly shows the appropriate list without a type selection prompt:
+
 ```bash
-# Select from menu
+# Directly shows Issue list
+mst github issue
+
+# Directly shows PR list  
+mst github pr
+```
+
+### Full Interactive Mode
+
+When no arguments are provided, it shows the type selection menu first:
+
+```bash
+# Shows type selection menu
 mst github
 ```
 
 Displayed menu:
 
 ```
-? What would you like to create a worktree from?
+? 何から演奏者を招集しますか？
 ❯ Pull Request
   Issue
-  Cancel
+  コメントを追加
 ```
 
-Then select from list:
+Then select from the chosen type's list:
 
 ```
-? Select a Pull Request:
+? Pull Requestを選択:
 ❯ #125 feat: Add dark mode support (enhancement, ui)
   #124 fix: Memory leak in background worker (bug, critical)
   #123 docs: Update API documentation (documentation)

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -651,15 +651,22 @@ async function executeGithubCommand(
   let finalNumber = number
 
   if (!finalNumber) {
-    try {
-      const result = await handleInteractiveMode()
-      finalType = result.type
-      finalNumber = result.number
-    } catch (error) {
-      if (error instanceof Error && error.message === 'INTERACTIVE_COMMENT_COMPLETE') {
-        return // コメント処理完了
+    // pr/issueが明示的に指定された場合は、その型に応じたアイテムを直接選択
+    if (finalType === 'pr' || finalType === 'issue') {
+      const items = await fetchItems(finalType as 'pr' | 'issue')
+      finalNumber = await selectItem(items, finalType as 'pr' | 'issue')
+    } else {
+      // typeも指定されていない場合のみ、完全なインタラクティブモード
+      try {
+        const result = await handleInteractiveMode()
+        finalType = result.type
+        finalNumber = result.number
+      } catch (error) {
+        if (error instanceof Error && error.message === 'INTERACTIVE_COMMENT_COMPLETE') {
+          return // コメント処理完了
+        }
+        throw error
       }
-      throw error
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixed issue where `mst github issue` and `mst github pr` commands showed unnecessary type selection prompt
- Commands now directly show the appropriate list when type is explicitly specified
- Improved user experience by reducing unnecessary interaction steps

## Changes
- Modified `executeGithubCommand` function to check if type is explicitly specified
- When type is 'pr' or 'issue', skip the full interactive mode
- Full interactive mode only appears when no arguments are provided
- Updated documentation to reflect the new behavior

## Test Plan
- [x] Tested `mst github issue` → directly shows Issue list ✅
- [x] Tested `mst github pr` → directly shows PR list (or empty message if no PRs) ✅
- [x] Tested `mst github` (no args) → shows type selection prompt ✅
- [x] All existing tests pass ✅
- [x] Code formatted with `pnpm format` ✅

Fixes #194

🤖 Generated with [Claude Code](https://claude.ai/code)