### PR TITLE
fix: ensure ConfigManager loads project config on new instances

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -272,6 +272,7 @@ export async function executeCreateCommand(
 ): Promise<void> {
   const manager = new GitWorktreeManager()
   const configManager = new ConfigManager()
+  await configManager.loadProjectConfig()
 
   // Git リポジトリの確認
   if (!(await manager.isGitRepository())) {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -76,6 +76,7 @@ async function executeOnSpecificMember(
 
   if (!silent) {
     const configManager = new ConfigManager()
+    await configManager.loadProjectConfig()
     const config = configManager.getAll()
     console.log(chalk.green(`\n🎼 演奏者 '${chalk.cyan(displayBranchName)}' でコマンドを実行`))
     console.log(chalk.gray(`📁 ${formatPath(targetWorktree.path, config)}`))
@@ -266,6 +267,7 @@ export const execCommand = new Command('exec')
           if (options.tmuxHorizontal) paneType = 'horizontal-split'
 
           const configManager = new ConfigManager()
+          await configManager.loadProjectConfig()
           const config = configManager.getAll()
           console.log(
             chalk.green(

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -509,6 +509,7 @@ async function createWorktreeFromGithub(
   }
 
   const configManager = new ConfigManager()
+  await configManager.loadProjectConfig()
   const fullConfig = configManager.getAll()
   spinner.succeed(
     `演奏者 '${chalk.cyan(branchName)}' を招集しました！\n` +
@@ -636,6 +637,7 @@ async function processWorktreeCreation(
     }
 
     const configManager = new ConfigManager()
+    await configManager.loadProjectConfig()
     const fullConfig = configManager.getAll()
     console.log(chalk.green(`\n🎼 GitHub統合による演奏者招集完了！`))
     console.log(chalk.gray(`📁 ${formatPath(worktreePath, fullConfig)}\n`))
@@ -670,6 +672,7 @@ async function processWorktreeCreation(
   }
 
   const configManager = new ConfigManager()
+  await configManager.loadProjectConfig()
   const fullConfig = configManager.getAll()
   console.log(chalk.green('\n✨ GitHub統合による演奏者の招集が完了しました！'))
   console.log(chalk.gray(`\ncd ${formatPath(worktreePath, fullConfig)} で移動できます`))

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -308,6 +308,7 @@ async function handlePruneOption(
   console.log(chalk.bold(`\n🗑️  ${staleWorktrees.length}件の古いworktreeがあります\n`))
 
   const configManager = new ConfigManager()
+  await configManager.loadProjectConfig()
   const config = configManager.getAll()
   staleWorktrees.forEach(wt => {
     const branch = wt.branch?.replace('refs/heads/', '') || wt.branch

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -58,6 +58,7 @@ async function checkoutPR(pr: PullRequest, gitManager: GitWorktreeManager): Prom
     if (existingWorktree) {
       checkoutSpinner.warn(`演奏者 '${prBranchName}' は既に存在します`)
       const configManager = new ConfigManager()
+      await configManager.loadProjectConfig()
       const config = configManager.getAll()
       console.log(chalk.gray(`📁 ${formatPath(existingWorktree.path, config)}`))
     } else {
@@ -72,6 +73,7 @@ async function checkoutPR(pr: PullRequest, gitManager: GitWorktreeManager): Prom
 
       checkoutSpinner.succeed(`PR #${pr.number} を演奏者 '${currentBranch}' として招集しました`)
       const configManager = new ConfigManager()
+      await configManager.loadProjectConfig()
       const config = configManager.getAll()
       console.log(chalk.gray(`📁 ${formatPath(worktreePath, config)}`))
       console.log(chalk.green(`\ncd ${formatPath(worktreePath, config)} で移動できます`))

--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -128,6 +128,7 @@ export const shellCommand = new Command('shell')
       }
 
       const configManager = new ConfigManager()
+      await configManager.loadProjectConfig()
       const config = configManager.getAll()
       console.log(chalk.green(`\n🎼 演奏者 '${chalk.cyan(branchName)}' に入ります...`))
       console.log(chalk.gray(`📁 ${formatPath(targetWorktree.path, config)}\n`))


### PR DESCRIPTION
## Summary
- Fixed issue where ConfigManager new instances weren't loading project configuration files
- Added `loadProjectConfig()` calls after creating ConfigManager instances in 6 command files
- This ensures user settings (`.maestro.local.json`) and project settings (`.maestro.json`) are properly loaded

## Problem
ConfigManagerの新規インスタンス作成時に`loadProjectConfig()`が呼ばれていないため、以下の設定ファイルが読み込まれていませんでした：
- `.maestro.local.json`（ユーザー設定）
- `.maestro.json`（プロジェクト設定）

これにより、`mst config set ui.pathDisplay relative`などで設定した値が一部のコマンドで反映されない問題が発生していました。

## Changes
以下のコマンドでConfigManagerインスタンス作成後に`await configManager.loadProjectConfig()`を追加：

### github.ts
- 511-513行目: `createWorktreeFromGithub`関数内
- 638-642行目: `processWorktreeCreation`関数内（tmuxオプション処理）
- 672-676行目: `processWorktreeCreation`関数内（完了メッセージ）

### create.ts
- 274-275行目: `executeCreateCommand`関数内

### health.ts  
- 310-312行目: `displayStaleWorktrees`関数内（非同期関数のみ対応）

### exec.ts
- 78-81行目: `executeCommandInWorktree`関数内
- 268-272行目: tmuxオプション処理部分

### shell.ts
- 130-134行目: `executeShellCommand`関数内（非同期関数のみ対応）

### review.ts
- 60-62行目: 既存worktree確認時
- 74-77行目: 新規worktree作成時

## Test plan
- [x] `pnpm test` - All tests pass (1043 passed)
- [x] `pnpm build` - Build succeeds
- [x] `pnpm typecheck` - No type errors
- [x] `pnpm lint` - No linting issues
- [x] `pnpm format` - Code is properly formatted

## Manual testing
1. `mst config set ui.pathDisplay relative` でパス表示を相対パスに設定
2. `mst github issue 123` を実行
3. worktreeのパスが相対パスで表示されることを確認

Fixes #203

🤖 Generated with [Claude Code](https://claude.ai/code)